### PR TITLE
optionally add track numbers to saved files

### DIFF
--- a/Spotify_Downloader.py
+++ b/Spotify_Downloader.py
@@ -15,6 +15,8 @@ For the program to work, the playlist URL pattern must follow the format of
 <sunnypatel124555@gmail.com> or open an issue in the repository.
 """
 
+from __future__ import annotations
+
 __version__ = "2.0.7"
 
 import concurrent.futures
@@ -23,7 +25,6 @@ import re
 import sys
 import threading
 import webbrowser
-from typing import Optional
 
 import requests
 from mutagen.easyid3 import EasyID3
@@ -114,7 +115,6 @@ SUPPORTED_FORMATS = {
     "wav": {"ext": "wav", "lossy": False},
 }
 SUPPORTED_QUALITIES = ("128", "192", "256", "320")
-SUPPORTED_OPTIONS = (True, False)
 
 # Resume manifest: a JSON-lines file dropped inside each playlist/album folder
 # recording which tracks already downloaded. On a re-run we skip those tracks
@@ -164,7 +164,7 @@ def load_config() -> dict:
             defaults["format"] = "mp3"
         if defaults["quality"] not in SUPPORTED_QUALITIES:
             defaults["quality"] = "192"
-        if defaults["include_track_number"] not in SUPPORTED_OPTIONS:
+        if not isinstance(defaults["include_track_number"], bool):
             defaults["include_track_number"] = True
         return defaults
     except (OSError, json.JSONDecodeError):
@@ -199,7 +199,7 @@ class MusicScraper(QThread):
 
     def __init__(
         self,
-        cancel_event: Optional[threading.Event] = None,
+        cancel_event: threading.Event | None = None,
         *,
         audio_format: str = "mp3",
         audio_quality: str = "192",
@@ -215,9 +215,7 @@ class MusicScraper(QThread):
         # audio_quality only applies to lossy formats (mp3/m4a/opus).
         self.audio_format = audio_format if audio_format in SUPPORTED_FORMATS else "mp3"
         self.audio_quality = audio_quality if audio_quality in SUPPORTED_QUALITIES else "192"
-        self.include_track_number = (
-            include_track_number if include_track_number in SUPPORTED_OPTIONS else True
-        )
+        self.include_track_number = bool(include_track_number)
         self._counter_lock = threading.Lock()
         self._failed_lock = threading.Lock()
         self._filename_lock = threading.Lock()
@@ -482,7 +480,7 @@ class MusicScraper(QThread):
             if filepath in self._in_flight_files:
                 if self.include_track_number:
                     filename = (
-                        f"{track_num}. {sanitized_title} - {sanitized_artists} [{track.id}].mp3"
+                        f"{track_num:02d}. {sanitized_title} - {sanitized_artists} [{track.id}].mp3"
                     )
                 else:
                     filename = f"{sanitized_title} - {sanitized_artists} [{track.id}].mp3"
@@ -873,7 +871,7 @@ class ScraperThread(QThread):
         self,
         spotify_link,
         music_folder=None,
-        cancel_event: Optional[threading.Event] = None,
+        cancel_event: threading.Event | None = None,
         *,
         audio_format: str = "mp3",
         audio_quality: str = "192",
@@ -908,7 +906,7 @@ class ScraperThread(QThread):
             self.progress_update.emit(f"{e}")
 
 
-def _fetch_cover_bytes(url: str) -> Optional[bytes]:
+def _fetch_cover_bytes(url: str) -> bytes | None:
     """Download cover image bytes, returning None on any failure."""
     if not url:
         return None
@@ -921,7 +919,7 @@ def _fetch_cover_bytes(url: str) -> Optional[bytes]:
     return None
 
 
-def _write_metadata_mp3(filename: str, tags: dict, cover_bytes: Optional[bytes]) -> None:
+def _write_metadata_mp3(filename: str, tags: dict, cover_bytes: bytes | None) -> None:
     """Write ID3 tags + embedded cover art to an MP3."""
     audio = EasyID3(filename)
     audio["title"] = tags.get("title", "")
@@ -938,7 +936,7 @@ def _write_metadata_mp3(filename: str, tags: dict, cover_bytes: Optional[bytes])
         id3.save()
 
 
-def _write_metadata_m4a(filename: str, tags: dict, cover_bytes: Optional[bytes]) -> None:
+def _write_metadata_m4a(filename: str, tags: dict, cover_bytes: bytes | None) -> None:
     """Write iTunes atom tags + embedded cover art to an M4A/MP4."""
     from mutagen.mp4 import MP4, MP4Cover
 
@@ -957,7 +955,7 @@ def _write_metadata_m4a(filename: str, tags: dict, cover_bytes: Optional[bytes])
     audio.save()
 
 
-def _write_metadata_flac(filename: str, tags: dict, cover_bytes: Optional[bytes]) -> None:
+def _write_metadata_flac(filename: str, tags: dict, cover_bytes: bytes | None) -> None:
     """Write Vorbis comments + embedded cover art to a FLAC."""
     from mutagen.flac import FLAC, Picture
 
@@ -1098,7 +1096,7 @@ class SettingsDialog(QDialog):
         form.addRow("Download folder:", folder_row)
         form.addRow("Audio format:", self._format_cb)
         form.addRow("Audio quality:", self._quality_cb)
-        form.addRow("Track number in filename", self._include_track_number_cb)
+        form.addRow("Track number in filename:", self._include_track_number_cb)
 
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         btns.accepted.connect(self.accept)

--- a/Spotify_Downloader.py
+++ b/Spotify_Downloader.py
@@ -23,6 +23,7 @@ import re
 import sys
 import threading
 import webbrowser
+from typing import Optional
 
 import requests
 from mutagen.easyid3 import EasyID3
@@ -39,6 +40,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtGui import QCursor, QImage, QPixmap
 from PyQt5.QtWidgets import (
     QApplication,
+    QCheckBox,
     QComboBox,
     QDialog,
     QDialogButtonBox,
@@ -112,6 +114,7 @@ SUPPORTED_FORMATS = {
     "wav": {"ext": "wav", "lossy": False},
 }
 SUPPORTED_QUALITIES = ("128", "192", "256", "320")
+SUPPORTED_OPTIONS = (True, False)
 
 # Resume manifest: a JSON-lines file dropped inside each playlist/album folder
 # recording which tracks already downloaded. On a re-run we skip those tracks
@@ -149,6 +152,7 @@ def load_config() -> dict:
         "download_path": None,
         "format": "mp3",
         "quality": "192",
+        "include_track_number": True,
     }
     try:
         with open(_config_path(), encoding="utf-8") as f:
@@ -160,6 +164,8 @@ def load_config() -> dict:
             defaults["format"] = "mp3"
         if defaults["quality"] not in SUPPORTED_QUALITIES:
             defaults["quality"] = "192"
+        if defaults["include_track_number"] not in SUPPORTED_OPTIONS:
+            defaults["include_track_number"] = True
         return defaults
     except (OSError, json.JSONDecodeError):
         return defaults
@@ -193,10 +199,11 @@ class MusicScraper(QThread):
 
     def __init__(
         self,
-        cancel_event: threading.Event | None = None,
+        cancel_event: Optional[threading.Event] = None,
         *,
         audio_format: str = "mp3",
         audio_quality: str = "192",
+        include_track_number: bool = True,
     ):
         super().__init__()
         self.counter = 0  # Initialize counter to zero
@@ -208,6 +215,9 @@ class MusicScraper(QThread):
         # audio_quality only applies to lossy formats (mp3/m4a/opus).
         self.audio_format = audio_format if audio_format in SUPPORTED_FORMATS else "mp3"
         self.audio_quality = audio_quality if audio_quality in SUPPORTED_QUALITIES else "192"
+        self.include_track_number = (
+            include_track_number if include_track_number in SUPPORTED_OPTIONS else True
+        )
         self._counter_lock = threading.Lock()
         self._failed_lock = threading.Lock()
         self._filename_lock = threading.Lock()
@@ -455,7 +465,12 @@ class MusicScraper(QThread):
         artists = track.artists
         sanitized_title = self.sanitize_text(track_title)
         sanitized_artists = self.sanitize_text(artists)
-        filename = f"{sanitized_title} - {sanitized_artists}.mp3"
+
+        if self.include_track_number:
+            filename = f"{track_num:02d}. {sanitized_title} - {sanitized_artists}.mp3"
+        else:
+            filename = f"{sanitized_title} - {sanitized_artists}.mp3"
+
         filepath = os.path.join(playlist_folder_path, filename)
 
         # Filename collision guard: two different tracks can sanitize to the
@@ -465,9 +480,16 @@ class MusicScraper(QThread):
         # lock; if taken, suffix with track id to de-dupe.
         with self._filename_lock:
             if filepath in self._in_flight_files:
+                if self.include_track_number:
+                    filename = (
+                        f"{track_num}. {sanitized_title} - {sanitized_artists} [{track.id}].mp3"
+                    )
+                else:
+                    filename = f"{sanitized_title} - {sanitized_artists} [{track.id}].mp3"
+
                 filepath = os.path.join(
                     playlist_folder_path,
-                    f"{sanitized_title} - {sanitized_artists} [{track.id}].mp3",
+                    filename,
                 )
             self._in_flight_files.add(filepath)
 
@@ -851,10 +873,11 @@ class ScraperThread(QThread):
         self,
         spotify_link,
         music_folder=None,
-        cancel_event: threading.Event | None = None,
+        cancel_event: Optional[threading.Event] = None,
         *,
         audio_format: str = "mp3",
         audio_quality: str = "192",
+        include_track_number: bool = True,
     ):
         super().__init__()
         self.spotify_link = spotify_link
@@ -864,6 +887,7 @@ class ScraperThread(QThread):
             cancel_event=self._cancel_event,
             audio_format=audio_format,
             audio_quality=audio_quality,
+            include_track_number=include_track_number,
         )
 
     def request_cancel(self):
@@ -884,7 +908,7 @@ class ScraperThread(QThread):
             self.progress_update.emit(f"{e}")
 
 
-def _fetch_cover_bytes(url: str) -> bytes | None:
+def _fetch_cover_bytes(url: str) -> Optional[bytes]:
     """Download cover image bytes, returning None on any failure."""
     if not url:
         return None
@@ -897,7 +921,7 @@ def _fetch_cover_bytes(url: str) -> bytes | None:
     return None
 
 
-def _write_metadata_mp3(filename: str, tags: dict, cover_bytes: bytes | None) -> None:
+def _write_metadata_mp3(filename: str, tags: dict, cover_bytes: Optional[bytes]) -> None:
     """Write ID3 tags + embedded cover art to an MP3."""
     audio = EasyID3(filename)
     audio["title"] = tags.get("title", "")
@@ -914,7 +938,7 @@ def _write_metadata_mp3(filename: str, tags: dict, cover_bytes: bytes | None) ->
         id3.save()
 
 
-def _write_metadata_m4a(filename: str, tags: dict, cover_bytes: bytes | None) -> None:
+def _write_metadata_m4a(filename: str, tags: dict, cover_bytes: Optional[bytes]) -> None:
     """Write iTunes atom tags + embedded cover art to an M4A/MP4."""
     from mutagen.mp4 import MP4, MP4Cover
 
@@ -933,7 +957,7 @@ def _write_metadata_m4a(filename: str, tags: dict, cover_bytes: bytes | None) ->
     audio.save()
 
 
-def _write_metadata_flac(filename: str, tags: dict, cover_bytes: bytes | None) -> None:
+def _write_metadata_flac(filename: str, tags: dict, cover_bytes: Optional[bytes]) -> None:
     """Write Vorbis comments + embedded cover art to a FLAC."""
     from mutagen.flac import FLAC, Picture
 
@@ -1067,10 +1091,14 @@ class SettingsDialog(QDialog):
         self._quality_cb.setCurrentText(f"{current_q} kbps")
         self._on_format_change(self._format_cb.currentText())
 
+        self._include_track_number_cb = QCheckBox()
+        self._include_track_number_cb.setChecked(self._config.get("include_track_number", True))
+
         form = QFormLayout()
         form.addRow("Download folder:", folder_row)
         form.addRow("Audio format:", self._format_cb)
         form.addRow("Audio quality:", self._quality_cb)
+        form.addRow("Track number in filename", self._include_track_number_cb)
 
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         btns.accepted.connect(self.accept)
@@ -1114,6 +1142,7 @@ class SettingsDialog(QDialog):
         self._config["download_path"] = self._folder_label.text()
         self._config["format"] = self._format_cb.currentText()
         self._config["quality"] = self._quality_cb.currentText().split()[0]
+        self._config["include_track_number"] = self._include_track_number_cb.isChecked()
         return self._config
 
 
@@ -1223,6 +1252,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     "download_path": self.download_path,
                     "format": new.get("format", "mp3"),
                     "quality": new.get("quality", "192"),
+                    "include_track_number": new.get("include_track_number", True),
                 }
             )
             save_config(self._config)
@@ -1274,6 +1304,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 cancel_event=self._cancel_event,
                 audio_format=self._config.get("format", "mp3"),
                 audio_quality=self._config.get("quality", "192"),
+                include_track_number=self._config.get("include_track_number", True),
             )
             self.scraper_thread.progress_update.connect(self.update_progress)
             self.scraper_thread.finished.connect(self.thread_finished)

--- a/Spotify_Downloader.py
+++ b/Spotify_Downloader.py
@@ -152,7 +152,7 @@ def load_config() -> dict:
         "download_path": None,
         "format": "mp3",
         "quality": "192",
-        "include_track_number": True,
+        "include_track_number": False,
     }
     try:
         with open(_config_path(), encoding="utf-8") as f:
@@ -165,7 +165,7 @@ def load_config() -> dict:
         if defaults["quality"] not in SUPPORTED_QUALITIES:
             defaults["quality"] = "192"
         if not isinstance(defaults["include_track_number"], bool):
-            defaults["include_track_number"] = True
+            defaults["include_track_number"] = False
         return defaults
     except (OSError, json.JSONDecodeError):
         return defaults
@@ -203,7 +203,7 @@ class MusicScraper(QThread):
         *,
         audio_format: str = "mp3",
         audio_quality: str = "192",
-        include_track_number: bool = True,
+        include_track_number: bool = False,
     ):
         super().__init__()
         self.counter = 0  # Initialize counter to zero
@@ -875,7 +875,7 @@ class ScraperThread(QThread):
         *,
         audio_format: str = "mp3",
         audio_quality: str = "192",
-        include_track_number: bool = True,
+        include_track_number: bool = False,
     ):
         super().__init__()
         self.spotify_link = spotify_link
@@ -1090,7 +1090,7 @@ class SettingsDialog(QDialog):
         self._on_format_change(self._format_cb.currentText())
 
         self._include_track_number_cb = QCheckBox()
-        self._include_track_number_cb.setChecked(self._config.get("include_track_number", True))
+        self._include_track_number_cb.setChecked(self._config.get("include_track_number", False))
 
         form = QFormLayout()
         form.addRow("Download folder:", folder_row)
@@ -1250,7 +1250,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     "download_path": self.download_path,
                     "format": new.get("format", "mp3"),
                     "quality": new.get("quality", "192"),
-                    "include_track_number": new.get("include_track_number", True),
+                    "include_track_number": new.get("include_track_number", False),
                 }
             )
             save_config(self._config)
@@ -1302,7 +1302,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 cancel_event=self._cancel_event,
                 audio_format=self._config.get("format", "mp3"),
                 audio_quality=self._config.get("quality", "192"),
-                include_track_number=self._config.get("include_track_number", True),
+                include_track_number=self._config.get("include_track_number", False),
             )
             self.scraper_thread.progress_update.connect(self.update_progress)
             self.scraper_thread.finished.connect(self.thread_finished)

--- a/tests/test_spotify_downloader.py
+++ b/tests/test_spotify_downloader.py
@@ -825,9 +825,10 @@ class TestParallelDownloads:
         playlist_folder.mkdir()
 
         tracks = [self._make_track(f"id{i}", f"Song {i}") for i in range(4)]
-        # Pre-create files for tracks 0 and 2
+        # Pre-create files for tracks 0 and 2 (track numbers 01 and 03,
+        # since iter_playlist_tracks yields position-1 as track_num)
         for i in (0, 2):
-            (playlist_folder / f"Song {i} - Artist.mp3").touch()
+            (playlist_folder / f"{i + 1:02d}. Song {i} - Artist.mp3").touch()
 
         downloaded = []
 
@@ -955,19 +956,23 @@ class TestParallelDownloads:
         scraper._parallel_mode = True
         scraper._total_tracks = 2
 
-        # Pre-claim the filename as if worker A got there first
-        base_name = "Song - Artist.mp3"
+        # Pre-claim the filename as if worker A got there first.
+        # include_track_number is on by default, so the primary path is
+        # padded `01. ...` and the collision-suffix path must be too.
+        base_name = "01. Song - Artist.mp3"
         base_path = os.path.join(str(playlist_folder), base_name)
         with scraper._filename_lock:
             scraper._in_flight_files.add(base_path)
 
-        # Worker B arrives — should get a suffixed filename
-        scraper._download_one_track(tracks[1], str(playlist_folder), None)
+        # Worker B arrives at track_num=1 too; should get a suffixed filename
+        scraper._download_one_track(tracks[1], str(playlist_folder), None, track_num=1)
 
         assert len(claimed_paths) == 1
         claimed = claimed_paths[0]
         assert claimed != base_path
         assert "[id_b]" in claimed
+        # collision-suffix variant must also be zero-padded for sort consistency
+        assert os.path.basename(claimed).startswith("01. ")
 
     def test_parallel_mode_emits_song_meta_per_track(self, tmp_path):
         """In parallel mode, song_meta IS emitted per track.
@@ -1306,3 +1311,120 @@ class TestTrackNumberMetadata:
         # Confirm tracknumber was NOT written
         calls = [c for c in mock_easy.__setitem__.call_args_list if c.args[0] == "tracknumber"]
         assert len(calls) == 0
+
+
+class TestTrackNumberInFilename:
+    """Tests for the include_track_number filename-prefix option.
+
+    Filename order must match playlist order in file managers (which sort
+    alphabetically). Zero-padding (`01.` not `1.`) is what makes that work
+    past nine tracks, so both the primary and the collision-guard paths
+    pad consistently.
+    """
+
+    def _track(self, tid="t1"):
+        from spotifydown_api import TrackInfo
+
+        return TrackInfo(
+            id=tid,
+            title="Title",
+            artists="Artist",
+            album="Album",
+            release_date="2024-01-01",
+            cover_url=None,
+            duration_ms=None,
+            preview_url=None,
+            raw={},
+        )
+
+    def _stub(self, scraper):
+        for sig in (
+            "song_meta",
+            "add_song_meta",
+            "dlprogress_signal",
+            "Resetprogress_signal",
+            "PlaylistID",
+            "song_Album",
+            "PlaylistCompleted",
+            "error_signal",
+            "count_updated",
+        ):
+            setattr(scraper, sig, MagicMock())
+
+    def test_default_on_writes_padded_prefix(self, tmp_path):
+        """Default include_track_number=True; filenames get the `NN. ` prefix."""
+        from Spotify_Downloader import MusicScraper
+
+        scraper = MusicScraper()
+        self._stub(scraper)
+        captured = []
+        scraper.download_track_audio = lambda _q, d, **_kw: (
+            (
+                captured.append(d),
+                open(d, "wb").close(),
+            )
+            and d
+        )
+
+        scraper._download_one_track(self._track(), str(tmp_path), "", track_num=3)
+        assert captured[0].endswith("03. Title - Artist.mp3")
+
+    def test_disabled_omits_prefix(self, tmp_path):
+        """include_track_number=False keeps the historical `Title - Artist.mp3` shape."""
+        from Spotify_Downloader import MusicScraper
+
+        scraper = MusicScraper(include_track_number=False)
+        self._stub(scraper)
+        captured = []
+        scraper.download_track_audio = lambda _q, d, **_kw: (
+            (
+                captured.append(d),
+                open(d, "wb").close(),
+            )
+            and d
+        )
+
+        scraper._download_one_track(self._track(), str(tmp_path), "", track_num=3)
+        assert captured[0].endswith("Title - Artist.mp3")
+        assert "03." not in os.path.basename(captured[0])
+
+    def test_collision_path_pads_consistently(self, tmp_path):
+        """When a name collides, the `[id]` suffix variant must also be `NN. `-padded.
+
+        Without this, the same playlist mixes `03. Foo - Bar.mp3` with
+        `3. Foo - Bar [id].mp3`, which sorts wrong and looks broken.
+        """
+        from Spotify_Downloader import MusicScraper
+
+        scraper = MusicScraper()
+        self._stub(scraper)
+        # Pretend the primary name is already claimed by a sibling worker
+        primary = str(tmp_path / "03. Title - Artist.mp3")
+        scraper._in_flight_files.add(primary)
+        captured = []
+        scraper.download_track_audio = lambda _q, d, **_kw: (
+            (
+                captured.append(d),
+                open(d, "wb").close(),
+            )
+            and d
+        )
+
+        scraper._download_one_track(self._track(tid="abc"), str(tmp_path), "", track_num=3)
+        assert captured[0].endswith("03. Title - Artist [abc].mp3")
+
+    def test_non_bool_config_falls_back_to_default(self):
+        """Bool validation in load_config must reject non-bool values (defensive)."""
+        from Spotify_Downloader import load_config
+
+        # We can't easily exercise the file path here, but the validation
+        # branch itself is small enough to exercise via construction:
+        scraper_cls_args = ["yes", "no", 1, 0, "true", None]
+        from Spotify_Downloader import MusicScraper
+
+        for v in scraper_cls_args:
+            s = MusicScraper(include_track_number=v)
+            assert isinstance(s.include_track_number, bool)
+        # And load_config returns a defaults dict; sanity-check the bool key
+        cfg = load_config()
+        assert isinstance(cfg["include_track_number"], bool)

--- a/tests/test_spotify_downloader.py
+++ b/tests/test_spotify_downloader.py
@@ -825,10 +825,10 @@ class TestParallelDownloads:
         playlist_folder.mkdir()
 
         tracks = [self._make_track(f"id{i}", f"Song {i}") for i in range(4)]
-        # Pre-create files for tracks 0 and 2 (track numbers 01 and 03,
-        # since iter_playlist_tracks yields position-1 as track_num)
+        # Pre-create files for tracks 0 and 2 (default include_track_number=False
+        # keeps the historical `Title - Artist.mp3` shape)
         for i in (0, 2):
-            (playlist_folder / f"{i + 1:02d}. Song {i} - Artist.mp3").touch()
+            (playlist_folder / f"Song {i} - Artist.mp3").touch()
 
         downloaded = []
 
@@ -957,22 +957,20 @@ class TestParallelDownloads:
         scraper._total_tracks = 2
 
         # Pre-claim the filename as if worker A got there first.
-        # include_track_number is on by default, so the primary path is
-        # padded `01. ...` and the collision-suffix path must be too.
-        base_name = "01. Song - Artist.mp3"
+        # Default include_track_number=False, so filenames keep the
+        # historical `Title - Artist.mp3` shape.
+        base_name = "Song - Artist.mp3"
         base_path = os.path.join(str(playlist_folder), base_name)
         with scraper._filename_lock:
             scraper._in_flight_files.add(base_path)
 
-        # Worker B arrives at track_num=1 too; should get a suffixed filename
-        scraper._download_one_track(tracks[1], str(playlist_folder), None, track_num=1)
+        # Worker B arrives - should get a suffixed filename
+        scraper._download_one_track(tracks[1], str(playlist_folder), None)
 
         assert len(claimed_paths) == 1
         claimed = claimed_paths[0]
         assert claimed != base_path
         assert "[id_b]" in claimed
-        # collision-suffix variant must also be zero-padded for sort consistency
-        assert os.path.basename(claimed).startswith("01. ")
 
     def test_parallel_mode_emits_song_meta_per_track(self, tmp_path):
         """In parallel mode, song_meta IS emitted per track.
@@ -1351,29 +1349,12 @@ class TestTrackNumberInFilename:
         ):
             setattr(scraper, sig, MagicMock())
 
-    def test_default_on_writes_padded_prefix(self, tmp_path):
-        """Default include_track_number=True; filenames get the `NN. ` prefix."""
+    def test_default_off_keeps_legacy_filename(self, tmp_path):
+        """Default is opt-out: `Title - Artist.mp3`, same as before this feature."""
         from Spotify_Downloader import MusicScraper
 
         scraper = MusicScraper()
-        self._stub(scraper)
-        captured = []
-        scraper.download_track_audio = lambda _q, d, **_kw: (
-            (
-                captured.append(d),
-                open(d, "wb").close(),
-            )
-            and d
-        )
-
-        scraper._download_one_track(self._track(), str(tmp_path), "", track_num=3)
-        assert captured[0].endswith("03. Title - Artist.mp3")
-
-    def test_disabled_omits_prefix(self, tmp_path):
-        """include_track_number=False keeps the historical `Title - Artist.mp3` shape."""
-        from Spotify_Downloader import MusicScraper
-
-        scraper = MusicScraper(include_track_number=False)
+        assert scraper.include_track_number is False
         self._stub(scraper)
         captured = []
         scraper.download_track_audio = lambda _q, d, **_kw: (
@@ -1388,6 +1369,24 @@ class TestTrackNumberInFilename:
         assert captured[0].endswith("Title - Artist.mp3")
         assert "03." not in os.path.basename(captured[0])
 
+    def test_enabled_writes_padded_prefix(self, tmp_path):
+        """When the user opts in, filenames get the zero-padded `NN. ` prefix."""
+        from Spotify_Downloader import MusicScraper
+
+        scraper = MusicScraper(include_track_number=True)
+        self._stub(scraper)
+        captured = []
+        scraper.download_track_audio = lambda _q, d, **_kw: (
+            (
+                captured.append(d),
+                open(d, "wb").close(),
+            )
+            and d
+        )
+
+        scraper._download_one_track(self._track(), str(tmp_path), "", track_num=3)
+        assert captured[0].endswith("03. Title - Artist.mp3")
+
     def test_collision_path_pads_consistently(self, tmp_path):
         """When a name collides, the `[id]` suffix variant must also be `NN. `-padded.
 
@@ -1396,7 +1395,7 @@ class TestTrackNumberInFilename:
         """
         from Spotify_Downloader import MusicScraper
 
-        scraper = MusicScraper()
+        scraper = MusicScraper(include_track_number=True)
         self._stub(scraper)
         # Pretend the primary name is already claimed by a sibling worker
         primary = str(tmp_path / "03. Title - Artist.mp3")


### PR DESCRIPTION
<div align="center">

# Pull Request

</div>

## Summary

Allows user to optionally save files with track number as ordered in the original playlist.

## Type of change

-  [x] feat (new feature)

## Scope (select all that apply)

- [x] Desktop (PyQt5 GUI)

## Details

Allows user to optionally save files with track number as ordered in the original playlist

## How I tested this

- OS and versions (Windows/macOS/Linux): Windows 11
- Python 3.13
- pip 25.2
- Commands run:

```bash
python Spotify_Downloader.py

In the settings window check/uncheck "Track number in filename"
Downloaded files will have/not have track numbers added to them
```

## Risks and rollbacks

Not tested on other machines.
I had to **import Optional** to make it work with python 3.13
