### PR TITLE
ci: harden release pipeline + supply-chain attestations

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,34 @@
+name: Dependency Review
+
+# PR-only check: refuses to merge a PR that introduces a dependency with
+# a known CVE. Does NOT email, does NOT open auto-PRs, does NOT run on push;
+# it just blocks unsafe diffs as a PR status check. (Distinct from Dependabot,
+# which is what generates the email storm and is intentionally disabled.)
+#
+# Action reference: https://github.com/actions/dependency-review-action
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: dep-review-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write   # post a single inline review summary on the PR
+
+jobs:
+  review:
+    name: Review dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          # Comment a summary once per PR instead of stacking new ones.
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,14 @@ concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   python-lint:
     name: Python Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,39 @@
+# =============================================================================
+# Sunnify Release Pipeline
+# =============================================================================
+# Builds platform installers (Win/Linux/macOS), generates an SBOM, attaches
+# SLSA L3 build provenance attestations, uploads to a GitHub Release, and
+# auto-bumps the Homebrew cask.
+#
+# Triggered manually via workflow_dispatch with a tag input (e.g. v2.0.8).
+# The tag must already exist (created via `git tag -a vX.Y.Z && git push --tags`)
+# and a draft or published release must already exist for that tag (created via
+# `gh release create vX.Y.Z --notes-file <file>`); this workflow only uploads
+# assets + provenance + SBOM to it.
+#
+# -----------------------------------------------------------------------------
+# Bumping the bundled FFmpeg (one of these every few months)
+# -----------------------------------------------------------------------------
+# Windows + Linux use BtbN/FFmpeg-Builds (released to GitHub, same source for
+# both platforms). macOS uses evermeet.cx (their stable versioned release).
+# To bump:
+#   1. Pick a fresh BtbN autobuild from
+#      https://github.com/BtbN/FFmpeg-Builds/releases
+#      Update FFMPEG_BTBN_TAG + FFMPEG_BTBN_BUILD below.
+#   2. Pick the matching stable FFmpeg release from
+#      https://evermeet.cx/ffmpeg/
+#      Update FFMPEG_MAC_VERSION below.
+#   3. Compute SHA256s locally:
+#        curl -fL <BtbN-win-zip> | shasum -a 256
+#        curl -fL <BtbN-linux-tar-xz> | shasum -a 256
+#        curl -fL <evermeet-ffmpeg-zip> | shasum -a 256
+#        curl -fL <evermeet-ffprobe-zip> | shasum -a 256
+#      Update the four FFMPEG_*_SHA256 env vars below.
+# Each platform's Download step then refuses to proceed if the SHA mismatches,
+# so a CDN swap or a typo aborts the build instead of silently shipping the
+# wrong binary.
+# -----------------------------------------------------------------------------
+
 name: Build Release
 
 on:
@@ -12,10 +48,24 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # BtbN (Windows + Linux): pinned autobuild
+  FFMPEG_BTBN_TAG: "autobuild-2026-06-08-14-24"
+  FFMPEG_BTBN_BUILD: "N-124881-g6028720d70"
+  FFMPEG_WIN_SHA256: "2cd538df51b0753547030dc997902606b13378df11db3866c81db7ca07fe7a54"
+  FFMPEG_LINUX_SHA256: "404a23515343c8c568a74ca39270879387d0ec92b9f52a44d416ecf7d9961230"
+  # evermeet.cx (macOS): pinned to FFmpeg release 8.1.1
+  FFMPEG_MAC_VERSION: "8.1.1"
+  FFMPEG_MAC_FFMPEG_SHA256: "4610988e2f54c243c50da73a09e4e2c36d9bb77546f9aa6c84cb328dcb1a98c1"
+  FFMPEG_MAC_FFPROBE_SHA256: "aeade29dee3c3844e9bcc974f4ae4b29cc4f87994177d77003a8589fa531009e"
+
 jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -25,16 +75,25 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
-      - name: Download FFmpeg
+      - name: Download and verify FFmpeg
         shell: pwsh
         run: |
-          $ffmpegUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
-          Invoke-WebRequest -Uri $ffmpegUrl -OutFile ffmpeg.zip
+          $tag = "${{ env.FFMPEG_BTBN_TAG }}"
+          $build = "${{ env.FFMPEG_BTBN_BUILD }}"
+          $expected = "${{ env.FFMPEG_WIN_SHA256 }}"
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$tag/ffmpeg-$build-win64-gpl.zip"
+          Write-Output "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile ffmpeg.zip
+          $actual = (Get-FileHash -Algorithm SHA256 ffmpeg.zip).Hash.ToLower()
+          if ($actual -ne $expected) {
+            Write-Error "FFmpeg SHA256 mismatch! expected=$expected actual=$actual"
+            exit 1
+          }
+          Write-Output "FFmpeg SHA256 verified: $actual"
           Expand-Archive -Path ffmpeg.zip -DestinationPath ffmpeg-temp
-          $ffmpegDir = Get-ChildItem -Path ffmpeg-temp -Directory | Select-Object -First 1
-          New-Item -ItemType Directory -Path ffmpeg -Force
-          Copy-Item -Path "$($ffmpegDir.FullName)\bin\ffmpeg.exe" -Destination ffmpeg\
-          Copy-Item -Path "$($ffmpegDir.FullName)\bin\ffprobe.exe" -Destination ffmpeg\
+          New-Item -ItemType Directory -Path ffmpeg -Force | Out-Null
+          Copy-Item -Path "ffmpeg-temp\ffmpeg-$build-win64-gpl\bin\ffmpeg.exe" -Destination ffmpeg\
+          Copy-Item -Path "ffmpeg-temp\ffmpeg-$build-win64-gpl\bin\ffprobe.exe" -Destination ffmpeg\
           Remove-Item -Recurse -Force ffmpeg-temp, ffmpeg.zip
           Get-ChildItem ffmpeg
 
@@ -46,19 +105,33 @@ jobs:
       - name: Build with PyInstaller
         run: pyinstaller Sunnify.spec
 
-      - name: Rename executable
+      - name: Rename + sanity-check executable
+        shell: pwsh
         run: |
-          move dist\Sunnify.exe dist\Sunnify-Windows.exe
+          Move-Item dist\Sunnify.exe dist\Sunnify-Windows.exe
+          $exe = Get-Item dist\Sunnify-Windows.exe
+          # Refuse to ship anything obviously broken. A real PyInstaller build
+          # with FFmpeg + PyQt5 is >100MB; anything under 50MB is a corrupt
+          # build that would just generate user reports.
+          if ($exe.Length -lt 50MB) {
+            Write-Error ("Sunnify-Windows.exe is {0:N1} MB; expected >50MB. Build is corrupt." -f ($exe.Length / 1MB))
+            exit 1
+          }
+          Write-Output ("Sunnify-Windows.exe verified: {0:N1} MB" -f ($exe.Length / 1MB))
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows-build
           path: dist/Sunnify-Windows.exe
+          if-no-files-found: error
 
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -83,19 +156,22 @@ jobs:
             libxcb-render-util0 \
             libxcb-shape0
 
-      - name: Download FFmpeg
+      - name: Download and verify FFmpeg
         run: |
-          # using BtbN/FFmpeg-Builds (same source as the Windows job).
-          # the previous source (johnvansickle.com) started returning a
-          # 435-byte html error page in june 2026 instead of the tarball.
-          curl -fL -o ffmpeg.tar.xz \
-            https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz
+          set -euo pipefail
+          TAG="${{ env.FFMPEG_BTBN_TAG }}"
+          BUILD="${{ env.FFMPEG_BTBN_BUILD }}"
+          EXPECTED="${{ env.FFMPEG_LINUX_SHA256 }}"
+          URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/${TAG}/ffmpeg-${BUILD}-linux64-gpl.tar.xz"
+          echo "Downloading ${URL}"
+          curl -fL -o ffmpeg.tar.xz "$URL"
+          echo "${EXPECTED}  ffmpeg.tar.xz" | sha256sum -c -
           tar -xf ffmpeg.tar.xz
           mkdir -p ffmpeg
-          cp ffmpeg-master-latest-linux64-gpl/bin/ffmpeg ffmpeg/
-          cp ffmpeg-master-latest-linux64-gpl/bin/ffprobe ffmpeg/
+          cp "ffmpeg-${BUILD}-linux64-gpl/bin/ffmpeg" ffmpeg/
+          cp "ffmpeg-${BUILD}-linux64-gpl/bin/ffprobe" ffmpeg/
           chmod +x ffmpeg/ffmpeg ffmpeg/ffprobe
-          rm -rf ffmpeg-master-latest-linux64-gpl ffmpeg.tar.xz
+          rm -rf "ffmpeg-${BUILD}-linux64-gpl" ffmpeg.tar.xz
           ls -la ffmpeg/
 
       - name: Install dependencies
@@ -106,20 +182,33 @@ jobs:
       - name: Build with PyInstaller
         run: pyinstaller Sunnify.spec
 
-      - name: Rename and set permissions
+      - name: Rename + sanity-check binary
         run: |
+          set -euo pipefail
           mv dist/Sunnify dist/Sunnify-Linux
           chmod +x dist/Sunnify-Linux
+          size=$(stat -c %s dist/Sunnify-Linux)
+          # See Windows comment; <50MB means the build is missing something.
+          if [ "$size" -lt 52428800 ]; then
+            echo "Sunnify-Linux is $((size / 1048576)) MB; expected >50MB. Build is corrupt." >&2
+            exit 1
+          fi
+          file dist/Sunnify-Linux | grep -E 'ELF' >/dev/null || { echo "Not a valid ELF binary"; exit 1; }
+          echo "Sunnify-Linux verified: $((size / 1048576)) MB"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-build
           path: dist/Sunnify-Linux
+          if-no-files-found: error
 
   build-macos:
     name: Build macOS
     runs-on: macos-14
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -129,12 +218,20 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
-      - name: Download FFmpeg
+      - name: Download and verify FFmpeg
         run: |
-          curl -L -o ffmpeg.zip https://evermeet.cx/ffmpeg/getrelease/zip
-          unzip ffmpeg.zip -d ffmpeg-temp
-          curl -L -o ffprobe.zip https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip
-          unzip ffprobe.zip -d ffmpeg-temp
+          set -euo pipefail
+          VERSION="${{ env.FFMPEG_MAC_VERSION }}"
+          EXP_FF="${{ env.FFMPEG_MAC_FFMPEG_SHA256 }}"
+          EXP_FP="${{ env.FFMPEG_MAC_FFPROBE_SHA256 }}"
+
+          curl -fL -o ffmpeg.zip "https://evermeet.cx/ffmpeg/ffmpeg-${VERSION}.zip"
+          shasum -a 256 -c <(echo "${EXP_FF}  ffmpeg.zip")
+          curl -fL -o ffprobe.zip "https://evermeet.cx/ffmpeg/ffprobe-${VERSION}.zip"
+          shasum -a 256 -c <(echo "${EXP_FP}  ffprobe.zip")
+
+          unzip -o ffmpeg.zip -d ffmpeg-temp
+          unzip -o ffprobe.zip -d ffmpeg-temp
           mkdir -p ffmpeg
           mv ffmpeg-temp/ffmpeg ffmpeg/
           mv ffmpeg-temp/ffprobe ffmpeg/
@@ -150,99 +247,261 @@ jobs:
       - name: Build with PyInstaller
         run: pyinstaller Sunnify.spec
 
-      - name: Create ZIP
+      - name: Create + sanity-check ZIP
         run: |
+          set -euo pipefail
           cd dist
+          test -d Sunnify.app || { echo "Sunnify.app missing"; exit 1; }
+          # Confirm bundled FFmpeg landed inside the .app before zipping. If
+          # PyInstaller missed it the user would just get an "FFmpeg not found"
+          # error at first download.
+          find Sunnify.app -name "ffmpeg" -type f | head -1 | grep -q ffmpeg || {
+            echo "Sunnify.app does not contain bundled FFmpeg"
+            exit 1
+          }
           zip -r Sunnify-macOS.zip Sunnify.app
+          size=$(stat -f %z Sunnify-macOS.zip)
+          if [ "$size" -lt 52428800 ]; then
+            echo "Sunnify-macOS.zip is $((size / 1048576)) MB; expected >50MB. Build is corrupt." >&2
+            exit 1
+          fi
+          echo "Sunnify-macOS.zip verified: $((size / 1048576)) MB"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: macos-build
           path: dist/Sunnify-macOS.zip
+          if-no-files-found: error
 
   upload-release:
     name: Upload to Release
     runs-on: ubuntu-latest
     needs: [build-windows, build-linux, build-macos]
+    timeout-minutes: 15
     permissions:
-      contents: write
+      contents: write       # upload assets to the release
+      id-token: write       # request OIDC token for sigstore signing
+      attestations: write   # write provenance attestations
     steps:
+      - name: Checkout repository (needed for syft SBOM scan of req.txt)
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
 
-      - name: List artifacts
-        run: find ./artifacts -type f
+      - name: Pre-upload sanity check
+        run: |
+          set -euo pipefail
+          fail=0
+          # 1. All three artifacts present and >50MB.
+          for f in artifacts/windows-build/Sunnify-Windows.exe \
+                   artifacts/linux-build/Sunnify-Linux \
+                   artifacts/macos-build/Sunnify-macOS.zip; do
+            if [ ! -f "$f" ]; then
+              echo "MISSING: $f"
+              fail=1
+              continue
+            fi
+            size=$(stat -c %s "$f")
+            if [ "$size" -lt 52428800 ]; then
+              echo "TOO SMALL: $f is $((size / 1048576)) MB"
+              fail=1
+            fi
+            echo "OK: $f ($((size / 1048576)) MB)"
+          done
+          # 2. Format checks.
+          file artifacts/windows-build/Sunnify-Windows.exe | grep -E 'PE32|MS-DOS executable|PE executable' >/dev/null \
+            || { echo "Windows binary is not PE format"; fail=1; }
+          file artifacts/linux-build/Sunnify-Linux | grep -E 'ELF' >/dev/null \
+            || { echo "Linux binary is not ELF"; fail=1; }
+          # 3. macOS zip contains the .app and bundled FFmpeg.
+          unzip -l artifacts/macos-build/Sunnify-macOS.zip | grep -q 'Sunnify.app/' \
+            || { echo "macOS zip missing Sunnify.app"; fail=1; }
+          unzip -l artifacts/macos-build/Sunnify-macOS.zip | grep -qiE 'ffmpeg' \
+            || { echo "macOS zip missing FFmpeg"; fail=1; }
+          if [ "$fail" -ne 0 ]; then
+            echo "Pre-upload sanity check FAILED"
+            exit 1
+          fi
+          echo "All artifacts verified"
 
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
+      - name: Generate SBOM (CycloneDX, Python dependency tree)
+        # syft scans the repo: walks req.txt + the codebase, produces a
+        # CycloneDX 1.5 JSON SBOM. We then attest provenance for it too so
+        # consumers can verify the SBOM came from this exact workflow run.
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: "."
+          format: cyclonedx-json
+          output-file: sunnify-sbom.cdx.json
+          upload-release-assets: false
+
+      - name: Attest build provenance (SLSA L3 via sigstore)
+        # Generates a sigstore-signed in-toto attestation linking each binary
+        # to this exact workflow run + the source commit. Users can verify:
+        #   gh attestation verify Sunnify-Linux \
+        #       --repo sunnypatell/sunnify-spotify-downloader
+        # Attestations are published to GitHub's attestation API and visible
+        # under the repo's Releases > Attestations tab.
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            ./artifacts/windows-build/Sunnify-Windows.exe
+            ./artifacts/linux-build/Sunnify-Linux
+            ./artifacts/macos-build/Sunnify-macOS.zip
+            ./sunnify-sbom.cdx.json
+
+      - name: Compute artifact SHA256s (for release notes)
+        id: shas
+        run: |
+          set -euo pipefail
+          {
+            echo "## SHA256 checksums"
+            echo ''
+            echo '```'
+            sha256sum artifacts/windows-build/Sunnify-Windows.exe | sed 's|artifacts/windows-build/||'
+            sha256sum artifacts/linux-build/Sunnify-Linux | sed 's|artifacts/linux-build/||'
+            sha256sum artifacts/macos-build/Sunnify-macOS.zip | sed 's|artifacts/macos-build/||'
+            sha256sum sunnify-sbom.cdx.json
+            echo '```'
+          } > /tmp/checksums.md
+          cat /tmp/checksums.md
+
+      - name: Upload assets to release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.event.inputs.tag }}
+          fail_on_unmatched_files: true
           files: |
             artifacts/windows-build/Sunnify-Windows.exe
             artifacts/linux-build/Sunnify-Linux
             artifacts/macos-build/Sunnify-macOS.zip
+            sunnify-sbom.cdx.json
 
   update-homebrew:
     name: Update Homebrew Cask
     runs-on: ubuntu-latest
     needs: [upload-release]
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
+      - name: Validate tag input
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          # Strict allowlist for the tag input so we can safely interpolate
+          # it into shell commands and the cask file. semver + optional
+          # pre-release / build suffix.
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
+            echo "Invalid tag format: '$TAG' (expected vX.Y.Z[-suffix])"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get macOS asset SHA256
+      - name: Fetch macOS asset + compute SHA256
         id: get-sha
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag }}
         run: |
-          # Wait for release assets to be fully available
-          sleep 10
-
-          # Get the SHA256 from the release asset digest
-          SHA256=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.event.inputs.tag }} \
-            --jq '.assets[] | select(.name == "Sunnify-macOS.zip") | .digest' | sed 's/sha256://')
-
-          if [ -z "$SHA256" ]; then
-            echo "Failed to get SHA256, calculating manually..."
-            gh release download ${{ github.event.inputs.tag }} --pattern "Sunnify-macOS.zip" --dir /tmp
-            SHA256=$(sha256sum /tmp/Sunnify-macOS.zip | cut -d' ' -f1)
-          fi
-
-          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          # Poll for the asset to be available. softprops finishes uploading
+          # before this job starts, but GitHub's release API is eventually
+          # consistent; first call after upload can 404. ~60s budget.
+          for i in $(seq 1 12); do
+            if gh release download "$TAG" \
+                 --repo "${{ github.repository }}" \
+                 --pattern "Sunnify-macOS.zip" \
+                 --dir /tmp \
+                 --clobber 2>/dev/null; then
+              break
+            fi
+            echo "Attempt $i: asset not yet available, waiting 5s"
+            sleep 5
+          done
+          test -f /tmp/Sunnify-macOS.zip || { echo "Asset never appeared after 60s"; exit 1; }
+          SHA256=$(sha256sum /tmp/Sunnify-macOS.zip | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
           echo "SHA256: $SHA256"
 
-      - name: Extract version from tag
-        id: version
+      - name: Update cask file (python, validated)
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          SHA256: ${{ steps.get-sha.outputs.sha256 }}
         run: |
-          VERSION="${{ github.event.inputs.tag }}"
-          VERSION="${VERSION#v}"  # Remove 'v' prefix
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
+          # Use Python with strict regex validation instead of sed -i with
+          # shell-interpolated values. Avoids two failure modes:
+          #   1. sed regex metacharacters (/, &, \) in the input breaking
+          #      the substitution silently or corrupting the file.
+          #   2. A future cask reformat (e.g. single quotes, raw strings)
+          #      causing the sed pattern to no-op without any error.
+          # Python validates both inputs against strict patterns first,
+          # asserts the file content was actually mutated, then writes.
+          python3 - <<'PYEOF'
+          import os
+          import re
+          import sys
 
-      - name: Update cask file
-        run: |
-          # Update version
-          sed -i 's/version "[^"]*"/version "${{ steps.version.outputs.version }}"/' Casks/sunnify.rb
+          tag = os.environ["TAG"]
+          sha = os.environ["SHA256"]
+          version = tag.lstrip("v")
 
-          # Update SHA256 (handles both quoted strings and :no_check symbol)
-          sed -i 's/sha256 "[^"]*"/sha256 "${{ steps.get-sha.outputs.sha256 }}"/' Casks/sunnify.rb
-          sed -i 's/sha256 :no_check/sha256 "${{ steps.get-sha.outputs.sha256 }}"/' Casks/sunnify.rb
+          if not re.fullmatch(r"[a-f0-9]{64}", sha):
+              sys.exit(f"Invalid SHA256: {sha!r}")
+          if not re.fullmatch(r"\d+\.\d+\.\d+([-+][a-zA-Z0-9.-]+)?", version):
+              sys.exit(f"Invalid version: {version!r}")
 
-          echo "Updated cask file:"
-          cat Casks/sunnify.rb
+          path = "Casks/sunnify.rb"
+          original = open(path).read()
+          updated = original
+
+          updated, n_version = re.subn(
+              r'version "[^"]*"', f'version "{version}"', updated, count=1
+          )
+          if n_version != 1:
+              sys.exit("Could not find version line to update")
+
+          # sha256 may appear as either "..." (normal) or :no_check (initial template)
+          updated, n_sha_str = re.subn(
+              r'sha256 "[^"]*"', f'sha256 "{sha}"', updated, count=1
+          )
+          updated, n_sha_sym = re.subn(
+              r'sha256 :no_check', f'sha256 "{sha}"', updated, count=1
+          )
+          if n_sha_str + n_sha_sym != 1:
+              sys.exit(
+                  f"Expected exactly one sha256 line; matched "
+                  f"{n_sha_str} quoted + {n_sha_sym} :no_check"
+              )
+
+          if updated == original:
+              sys.exit("Cask file unchanged after substitution; aborting")
+
+          open(path, "w").write(updated)
+          PYEOF
+          echo "Cask updated:"
+          head -10 Casks/sunnify.rb
 
       - name: Commit and push
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/sunnify.rb
-          git commit -m "chore(homebrew): auto-update cask to ${{ github.event.inputs.tag }}" || echo "No changes to commit"
+          if git diff --cached --quiet; then
+            echo "No cask changes to commit (already at $TAG)"
+            exit 0
+          fi
+          git commit -m "chore(homebrew): auto-update cask to $TAG"
           git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,8 +410,9 @@ jobs:
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-
+            scan
+            source
             --sbom=./sunnify-sbom.cdx.json
-            --skip-git
 
       - name: Attest build provenance (SLSA L3 via sigstore)
         # Generates a sigstore-signed in-toto provenance attestation linking

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,35 @@
 # =============================================================================
 # Sunnify Release Pipeline
 # =============================================================================
-# Builds platform installers (Win/Linux/macOS), generates an SBOM, attaches
-# SLSA L3 build provenance attestations, uploads to a GitHub Release, and
-# auto-bumps the Homebrew cask.
+# Builds platform installers (Win/Linux/macOS), generates a CycloneDX SBOM,
+# attaches SLSA L3 build provenance + SBOM attestations (sigstore-signed via
+# the runner's OIDC identity, verifiable with `gh attestation verify`),
+# uploads everything to a GitHub Release, and auto-bumps the Homebrew cask.
 #
 # Triggered manually via workflow_dispatch with a tag input (e.g. v2.0.8).
 # The tag must already exist (created via `git tag -a vX.Y.Z && git push --tags`)
 # and a draft or published release must already exist for that tag (created via
 # `gh release create vX.Y.Z --notes-file <file>`); this workflow only uploads
-# assets + provenance + SBOM to it.
+# assets + attestations to it.
+#
+# Pass dry_run=true to test the pipeline end-to-end on a throwaway tag without
+# touching main (skips the cask-update job entirely).
 #
 # -----------------------------------------------------------------------------
 # Bumping the bundled FFmpeg (one of these every few months)
 # -----------------------------------------------------------------------------
-# Windows + Linux use BtbN/FFmpeg-Builds (released to GitHub, same source for
-# both platforms). macOS uses evermeet.cx (their stable versioned release).
-# To bump:
+# Windows + Linux use BtbN/FFmpeg-Builds (released to GitHub). macOS uses
+# evermeet.cx (their stable versioned release). To bump:
 #   1. Pick a fresh BtbN autobuild from
 #      https://github.com/BtbN/FFmpeg-Builds/releases
 #      Update FFMPEG_BTBN_TAG + FFMPEG_BTBN_BUILD below.
 #   2. Pick the matching stable FFmpeg release from
 #      https://evermeet.cx/ffmpeg/
 #      Update FFMPEG_MAC_VERSION below.
-#   3. Compute SHA256s locally:
-#        curl -fL <BtbN-win-zip> | shasum -a 256
-#        curl -fL <BtbN-linux-tar-xz> | shasum -a 256
-#        curl -fL <evermeet-ffmpeg-zip> | shasum -a 256
-#        curl -fL <evermeet-ffprobe-zip> | shasum -a 256
-#      Update the four FFMPEG_*_SHA256 env vars below.
-# Each platform's Download step then refuses to proceed if the SHA mismatches,
-# so a CDN swap or a typo aborts the build instead of silently shipping the
-# wrong binary.
+#   3. Compute SHA256s locally and update the four FFMPEG_*_SHA256 env vars:
+#        curl -fsL "<url>" | shasum -a 256
+# If a SHA mismatches at download time the build aborts before extraction, so
+# a CDN swap or a typo can never silently ship the wrong binary.
 # -----------------------------------------------------------------------------
 
 name: Build Release
@@ -43,10 +41,18 @@ on:
         description: "Release tag to upload assets to (e.g., v2.0.0)"
         required: true
         type: string
+      dry_run:
+        description: "Dry-run: skip Homebrew cask update + keep the release as draft"
+        required: false
+        type: boolean
+        default: false
 
+# Lock per-tag so two real releases on different tags can run independently,
+# but a re-dispatch on the same tag still serializes (or cancels if you want
+# the latest). The pre-existing branch-scoped group was over-broad.
 concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: true
+  group: release-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
 
 env:
   # BtbN (Windows + Linux): pinned autobuild
@@ -76,26 +82,25 @@ jobs:
           cache: "pip"
 
       - name: Download and verify FFmpeg
-        shell: pwsh
+        shell: bash
+        # bash on windows-latest gets curl.exe; matches Linux/macOS exactly
+        # and gives us -fL fail-on-HTTP-error parity that Invoke-WebRequest
+        # silently lacks on -OutFile.
         run: |
-          $tag = "${{ env.FFMPEG_BTBN_TAG }}"
-          $build = "${{ env.FFMPEG_BTBN_BUILD }}"
-          $expected = "${{ env.FFMPEG_WIN_SHA256 }}"
-          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$tag/ffmpeg-$build-win64-gpl.zip"
-          Write-Output "Downloading $url"
-          Invoke-WebRequest -Uri $url -OutFile ffmpeg.zip
-          $actual = (Get-FileHash -Algorithm SHA256 ffmpeg.zip).Hash.ToLower()
-          if ($actual -ne $expected) {
-            Write-Error "FFmpeg SHA256 mismatch! expected=$expected actual=$actual"
-            exit 1
-          }
-          Write-Output "FFmpeg SHA256 verified: $actual"
-          Expand-Archive -Path ffmpeg.zip -DestinationPath ffmpeg-temp
-          New-Item -ItemType Directory -Path ffmpeg -Force | Out-Null
-          Copy-Item -Path "ffmpeg-temp\ffmpeg-$build-win64-gpl\bin\ffmpeg.exe" -Destination ffmpeg\
-          Copy-Item -Path "ffmpeg-temp\ffmpeg-$build-win64-gpl\bin\ffprobe.exe" -Destination ffmpeg\
-          Remove-Item -Recurse -Force ffmpeg-temp, ffmpeg.zip
-          Get-ChildItem ffmpeg
+          set -euo pipefail
+          TAG="${{ env.FFMPEG_BTBN_TAG }}"
+          BUILD="${{ env.FFMPEG_BTBN_BUILD }}"
+          EXPECTED="${{ env.FFMPEG_WIN_SHA256 }}"
+          URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/${TAG}/ffmpeg-${BUILD}-win64-gpl.zip"
+          echo "Downloading ${URL}"
+          curl -fL -o ffmpeg.zip "$URL"
+          echo "${EXPECTED}  ffmpeg.zip" | sha256sum -c -
+          unzip -q ffmpeg.zip
+          mkdir -p ffmpeg
+          cp "ffmpeg-${BUILD}-win64-gpl/bin/ffmpeg.exe" ffmpeg/
+          cp "ffmpeg-${BUILD}-win64-gpl/bin/ffprobe.exe" ffmpeg/
+          rm -rf "ffmpeg-${BUILD}-win64-gpl" ffmpeg.zip
+          ls -la ffmpeg/
 
       - name: Install dependencies
         run: |
@@ -106,18 +111,18 @@ jobs:
         run: pyinstaller Sunnify.spec
 
       - name: Rename + sanity-check executable
-        shell: pwsh
+        shell: bash
         run: |
-          Move-Item dist\Sunnify.exe dist\Sunnify-Windows.exe
-          $exe = Get-Item dist\Sunnify-Windows.exe
-          # Refuse to ship anything obviously broken. A real PyInstaller build
-          # with FFmpeg + PyQt5 is >100MB; anything under 50MB is a corrupt
-          # build that would just generate user reports.
-          if ($exe.Length -lt 50MB) {
-            Write-Error ("Sunnify-Windows.exe is {0:N1} MB; expected >50MB. Build is corrupt." -f ($exe.Length / 1MB))
+          set -euo pipefail
+          mv dist/Sunnify.exe dist/Sunnify-Windows.exe
+          size=$(stat -c %s dist/Sunnify-Windows.exe 2>/dev/null || stat -f %z dist/Sunnify-Windows.exe)
+          # A real PyInstaller build with FFmpeg + PyQt5 is >100MB; anything
+          # under 50MB is a corrupt build that would just generate user reports.
+          if [ "$size" -lt 52428800 ]; then
+            echo "Sunnify-Windows.exe is $((size / 1048576)) MB; expected >50MB. Build is corrupt." >&2
             exit 1
-          }
-          Write-Output ("Sunnify-Windows.exe verified: {0:N1} MB" -f ($exe.Length / 1MB))
+          fi
+          echo "Sunnify-Windows.exe verified: $((size / 1048576)) MB"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -188,7 +193,6 @@ jobs:
           mv dist/Sunnify dist/Sunnify-Linux
           chmod +x dist/Sunnify-Linux
           size=$(stat -c %s dist/Sunnify-Linux)
-          # See Windows comment; <50MB means the build is missing something.
           if [ "$size" -lt 52428800 ]; then
             echo "Sunnify-Linux is $((size / 1048576)) MB; expected >50MB. Build is corrupt." >&2
             exit 1
@@ -280,12 +284,17 @@ jobs:
     needs: [build-windows, build-linux, build-macos]
     timeout-minutes: 15
     permissions:
-      contents: write       # upload assets to the release
+      contents: write       # upload assets + (optionally) toggle draft
       id-token: write       # request OIDC token for sigstore signing
-      attestations: write   # write provenance attestations
+      attestations: write   # write provenance + SBOM attestations
     steps:
-      - name: Checkout repository (needed for syft SBOM scan of req.txt)
+      - name: Checkout repository at the release tag
+        # Needed both for syft (req.txt + source tree) and for the source
+        # tarball we attest below. Pinning to the tag is what makes the
+        # source tarball deterministic per release.
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -328,64 +337,133 @@ jobs:
           fi
           echo "All artifacts verified"
 
-      - name: Generate SBOM (CycloneDX, Python dependency tree)
-        # syft scans the repo: walks req.txt + the codebase, produces a
-        # CycloneDX 1.5 JSON SBOM. We then attest provenance for it too so
-        # consumers can verify the SBOM came from this exact workflow run.
+      - name: Generate SBOM (CycloneDX, scoped to delivered artifacts)
+        # syft scans the artifacts directory (the actual zips/binaries about
+        # to be uploaded), not the source tree. This means the SBOM describes
+        # what users will install, not just what's in req.txt. PyInstaller
+        # bundles are opaque to most cataloguers so the SBOM is intentionally
+        # shallow, but it is bound by digest to the binaries via the
+        # attest-sbom step below, so a tampered or unrelated SBOM cannot pass
+        # `gh attestation verify`.
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: "."
+          path: "./artifacts"
           format: cyclonedx-json
           output-file: sunnify-sbom.cdx.json
           upload-release-assets: false
 
       - name: Attest build provenance (SLSA L3 via sigstore)
-        # Generates a sigstore-signed in-toto attestation linking each binary
-        # to this exact workflow run + the source commit. Users can verify:
+        # Generates a sigstore-signed in-toto provenance attestation linking
+        # each binary to this exact workflow run + source commit. Users verify:
         #   gh attestation verify Sunnify-Linux \
         #       --repo sunnypatell/sunnify-spotify-downloader
-        # Attestations are published to GitHub's attestation API and visible
-        # under the repo's Releases > Attestations tab.
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             ./artifacts/windows-build/Sunnify-Windows.exe
             ./artifacts/linux-build/Sunnify-Linux
             ./artifacts/macos-build/Sunnify-macOS.zip
-            ./sunnify-sbom.cdx.json
 
-      - name: Compute artifact SHA256s (for release notes)
-        id: shas
+      - name: Attest SBOM
+        # Separate sigstore-signed attestation binding each binary's digest to
+        # the SBOM digest. This is the in-toto "SBOM" predicate (not the
+        # "provenance" predicate above), so consumers can ask the supply-chain
+        # question "what's IN this binary?" against the same chain of trust as
+        # "where did this binary come from?".
+        uses: actions/attest-sbom@10926c72720ffc3f7b666661c8e55b1344e2a365 # v2 (Sep 2024)
+        with:
+          subject-path: |
+            ./artifacts/windows-build/Sunnify-Windows.exe
+            ./artifacts/linux-build/Sunnify-Linux
+            ./artifacts/macos-build/Sunnify-macOS.zip
+          sbom-path: ./sunnify-sbom.cdx.json
+
+      - name: Build + attest source tarball
+        # Deterministic source tarball at the release commit. Lets consumers
+        # ask "what source actually corresponds to this binary?" without
+        # trusting GitHub's rendered "Source code (zip)" autoreleases (which
+        # have no provenance attestation and can be regenerated server-side).
+        # The provenance attestation we already produce above covers it too.
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          git archive --format=tar.gz \
+            --prefix="sunnify-${TAG}/" \
+            -o "sunnify-${TAG}-source.tar.gz" \
+            "$TAG"
+          ls -la "sunnify-${TAG}-source.tar.gz"
+
+      - name: Attest source tarball
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ./sunnify-${{ github.event.inputs.tag }}-source.tar.gz
+
+      - name: Generate checksums manifest
+        # SHA256 of every release asset, in the standard `<hash>  <name>`
+        # format that `sha256sum -c checksums.txt` consumes. Pinned to a
+        # stable filename so users can script verification without parsing
+        # release JSON.
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
           {
-            echo "## SHA256 checksums"
-            echo ''
-            echo '```'
-            sha256sum artifacts/windows-build/Sunnify-Windows.exe | sed 's|artifacts/windows-build/||'
-            sha256sum artifacts/linux-build/Sunnify-Linux | sed 's|artifacts/linux-build/||'
-            sha256sum artifacts/macos-build/Sunnify-macOS.zip | sed 's|artifacts/macos-build/||'
-            sha256sum sunnify-sbom.cdx.json
-            echo '```'
-          } > /tmp/checksums.md
-          cat /tmp/checksums.md
+            sha256sum \
+              artifacts/windows-build/Sunnify-Windows.exe \
+              artifacts/linux-build/Sunnify-Linux \
+              artifacts/macos-build/Sunnify-macOS.zip \
+              sunnify-sbom.cdx.json \
+              "sunnify-${TAG}-source.tar.gz" \
+              | sed -E 's|artifacts/[^/]+/||'
+          } > checksums.txt
+          echo "--- checksums.txt ---"
+          cat checksums.txt
+
+      - name: Delete any pre-existing release assets (idempotency)
+        # softprops/action-gh-release uploads without overwriting; if this job
+        # is re-run after a partial failure (e.g. attestation step crashed),
+        # stale artifact bytes from the first attempt would persist alongside
+        # fresh ones. Delete-then-upload makes the job exactly idempotent.
+        # `|| true` because 404 is the normal case on the first run.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          for asset in \
+              Sunnify-Windows.exe \
+              Sunnify-Linux \
+              Sunnify-macOS.zip \
+              sunnify-sbom.cdx.json \
+              "sunnify-${TAG}-source.tar.gz" \
+              checksums.txt; do
+            gh release delete-asset "$TAG" "$asset" \
+              --repo "${{ github.repository }}" \
+              --yes 2>/dev/null || true
+          done
 
       - name: Upload assets to release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.event.inputs.tag }}
+          # If dry_run, keep the release as a draft so it isn't user-visible.
+          draft: ${{ inputs.dry_run }}
           fail_on_unmatched_files: true
           files: |
             artifacts/windows-build/Sunnify-Windows.exe
             artifacts/linux-build/Sunnify-Linux
             artifacts/macos-build/Sunnify-macOS.zip
             sunnify-sbom.cdx.json
+            sunnify-${{ github.event.inputs.tag }}-source.tar.gz
+            checksums.txt
 
   update-homebrew:
     name: Update Homebrew Cask
     runs-on: ubuntu-latest
     needs: [upload-release]
     timeout-minutes: 10
+    # Skipped entirely on dry-run so the test never touches main.
+    if: ${{ inputs.dry_run != true }}
     permissions:
       contents: write
     steps:
@@ -393,11 +471,12 @@ jobs:
         env:
           TAG: ${{ github.event.inputs.tag }}
         run: |
-          # Strict allowlist for the tag input so we can safely interpolate
-          # it into shell commands and the cask file. semver + optional
-          # pre-release / build suffix.
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9.-]+)?$ ]]; then
-            echo "Invalid tag format: '$TAG' (expected vX.Y.Z[-suffix])"
+          # Strict semver allowlist. Pre-release/build suffix must start with
+          # an alphanumeric (rules out v1.0.0--bad and similar typos) and only
+          # one of -<pre-release> or +<build> is allowed (matching the strict
+          # SemVer 2.0.0 grammar minus simultaneous pre-release+build).
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9][a-zA-Z0-9.-]*|\+[a-zA-Z0-9][a-zA-Z0-9.-]*)?$ ]]; then
+            echo "Invalid tag format: '$TAG' (expected vX.Y.Z[-prerelease] or vX.Y.Z[+build])"
             exit 1
           fi
 
@@ -433,19 +512,16 @@ jobs:
           echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
           echo "SHA256: $SHA256"
 
-      - name: Update cask file (python, validated)
+      - name: Update cask file (python, line-anchored regex)
         env:
           TAG: ${{ github.event.inputs.tag }}
           SHA256: ${{ steps.get-sha.outputs.sha256 }}
         run: |
-          # Use Python with strict regex validation instead of sed -i with
-          # shell-interpolated values. Avoids two failure modes:
-          #   1. sed regex metacharacters (/, &, \) in the input breaking
-          #      the substitution silently or corrupting the file.
-          #   2. A future cask reformat (e.g. single quotes, raw strings)
-          #      causing the sed pattern to no-op without any error.
-          # Python validates both inputs against strict patterns first,
-          # asserts the file content was actually mutated, then writes.
+          # Python instead of sed -i: strict input validation, line-anchored
+          # regex (so a commented `# version "x.y.z"` example never gets
+          # rewritten), exact-once substitution, fails closed if either
+          # substitution didn't fire. Belt-and-suspenders versus the
+          # silent-fail modes the earlier sed implementation had.
           python3 - <<'PYEOF'
           import os
           import re
@@ -457,36 +533,55 @@ jobs:
 
           if not re.fullmatch(r"[a-f0-9]{64}", sha):
               sys.exit(f"Invalid SHA256: {sha!r}")
-          if not re.fullmatch(r"\d+\.\d+\.\d+([-+][a-zA-Z0-9.-]+)?", version):
+          # Mirror the bash semver allowlist above.
+          if not re.fullmatch(
+              r"\d+\.\d+\.\d+(-[a-zA-Z0-9][a-zA-Z0-9.-]*|\+[a-zA-Z0-9][a-zA-Z0-9.-]*)?",
+              version,
+          ):
               sys.exit(f"Invalid version: {version!r}")
 
           path = "Casks/sunnify.rb"
-          original = open(path).read()
+          with open(path) as f:
+              original = f.read()
           updated = original
 
+          # Line-anchored so commented example lines never match.
           updated, n_version = re.subn(
-              r'version "[^"]*"', f'version "{version}"', updated, count=1
+              r'^(\s*)version "[^"]*"',
+              rf'\1version "{version}"',
+              updated,
+              count=1,
+              flags=re.MULTILINE,
           )
           if n_version != 1:
-              sys.exit("Could not find version line to update")
+              sys.exit("Could not find a top-level `version` line to update")
 
-          # sha256 may appear as either "..." (normal) or :no_check (initial template)
+          # sha256 appears as either "..." (normal) or :no_check (initial template).
           updated, n_sha_str = re.subn(
-              r'sha256 "[^"]*"', f'sha256 "{sha}"', updated, count=1
+              r'^(\s*)sha256 "[^"]*"',
+              rf'\1sha256 "{sha}"',
+              updated,
+              count=1,
+              flags=re.MULTILINE,
           )
           updated, n_sha_sym = re.subn(
-              r'sha256 :no_check', f'sha256 "{sha}"', updated, count=1
+              r'^(\s*)sha256 :no_check',
+              rf'\1sha256 "{sha}"',
+              updated,
+              count=1,
+              flags=re.MULTILINE,
           )
           if n_sha_str + n_sha_sym != 1:
               sys.exit(
-                  f"Expected exactly one sha256 line; matched "
+                  f"Expected exactly one top-level sha256 line; matched "
                   f"{n_sha_str} quoted + {n_sha_sym} :no_check"
               )
 
           if updated == original:
               sys.exit("Cask file unchanged after substitution; aborting")
 
-          open(path, "w").write(updated)
+          with open(path, "w") as f:
+              f.write(updated)
           PYEOF
           echo "Cask updated:"
           head -10 Casks/sunnify.rb
@@ -504,4 +599,12 @@ jobs:
             exit 0
           fi
           git commit -m "chore(homebrew): auto-update cask to $TAG"
-          git push origin main
+          # If branch protection is later added requiring PR review for main,
+          # this push will 403. Surface a clear message instead of just a stack.
+          if ! git push origin main; then
+            echo "::error::git push origin main failed."
+            echo "::error::If branch protection now requires reviews on main,"
+            echo "::error::either allow github-actions[bot] to push, or change"
+            echo "::error::this step to open a PR via 'gh pr create'."
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,13 +404,14 @@ jobs:
         # maintained, queries the OSV.dev database. Fails closed so a new
         # CVE in a transitive dep blocks the upload until the maintainer
         # either bumps the dep or explicitly waives via a code change here.
+        # The action subpath is required because the repo root action.yml
+        # is metadata-only; the runnable Docker action lives in the subdir.
         # ref: https://google.github.io/osv-scanner/
-        uses: google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-
             --sbom=./sunnify-sbom.cdx.json
             --skip-git
-            --fail-on-vuln=HIGH
 
       - name: Attest build provenance (SLSA L3 via sigstore)
         # Generates a sigstore-signed in-toto provenance attestation linking

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,13 +432,16 @@ jobs:
         # "provenance" predicate above), so consumers can ask the supply-chain
         # question "what's IN this binary?" against the same chain of trust as
         # "where did this binary come from?".
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        # Using actions/attest directly with a CycloneDX predicate-type
+        # because actions/attest-sbom is now a deprecated wrapper.
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
             ./artifacts/windows-build/Sunnify-Windows.exe
             ./artifacts/linux-build/Sunnify-Linux
             ./artifacts/macos-build/Sunnify-macOS.zip
-          sbom-path: ./sunnify-sbom.cdx.json
+          predicate-type: "https://cyclonedx.org/bom/v1.5"
+          predicate-path: ./sunnify-sbom.cdx.json
 
       - name: Build + attest source tarball
         # Deterministic source tarball at the release commit. Lets consumers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,22 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: "pip"
+
+      - name: Cache FFmpeg archive
+        id: ffmpeg-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ffmpeg-cache
+          # Cache is invalidated automatically the moment any env var
+          # in the key changes - so a version bump auto-busts the cache.
+          key: ffmpeg-${{ runner.os }}-${{ env.FFMPEG_BTBN_BUILD }}-${{ env.FFMPEG_MAC_VERSION }}
 
       - name: Download and verify FFmpeg
         shell: bash
@@ -92,14 +101,20 @@ jobs:
           BUILD="${{ env.FFMPEG_BTBN_BUILD }}"
           EXPECTED="${{ env.FFMPEG_WIN_SHA256 }}"
           URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/${TAG}/ffmpeg-${BUILD}-win64-gpl.zip"
-          echo "Downloading ${URL}"
-          curl -fL -o ffmpeg.zip "$URL"
-          echo "${EXPECTED}  ffmpeg.zip" | sha256sum -c -
-          unzip -q ffmpeg.zip
+          mkdir -p ffmpeg-cache
+          if [ -f "ffmpeg-cache/ffmpeg.zip" ]; then
+            echo "Using cached download"
+          else
+            echo "Downloading ${URL}"
+            curl -fL -o ffmpeg-cache/ffmpeg.zip "$URL"
+          fi
+          # Verify EVERY run, cache hit or miss - cache cannot bypass the SHA gate.
+          echo "${EXPECTED}  ffmpeg-cache/ffmpeg.zip" | sha256sum -c -
+          unzip -q ffmpeg-cache/ffmpeg.zip
           mkdir -p ffmpeg
           cp "ffmpeg-${BUILD}-win64-gpl/bin/ffmpeg.exe" ffmpeg/
           cp "ffmpeg-${BUILD}-win64-gpl/bin/ffprobe.exe" ffmpeg/
-          rm -rf "ffmpeg-${BUILD}-win64-gpl" ffmpeg.zip
+          rm -rf "ffmpeg-${BUILD}-win64-gpl"
           ls -la ffmpeg/
 
       - name: Install dependencies
@@ -125,7 +140,7 @@ jobs:
           echo "Sunnify-Windows.exe verified: $((size / 1048576)) MB"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-build
           path: dist/Sunnify-Windows.exe
@@ -138,10 +153,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -161,6 +176,13 @@ jobs:
             libxcb-render-util0 \
             libxcb-shape0
 
+      - name: Cache FFmpeg archive
+        id: ffmpeg-cache-linux
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ffmpeg-cache
+          key: ffmpeg-${{ runner.os }}-${{ env.FFMPEG_BTBN_BUILD }}-${{ env.FFMPEG_MAC_VERSION }}
+
       - name: Download and verify FFmpeg
         run: |
           set -euo pipefail
@@ -168,15 +190,20 @@ jobs:
           BUILD="${{ env.FFMPEG_BTBN_BUILD }}"
           EXPECTED="${{ env.FFMPEG_LINUX_SHA256 }}"
           URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/${TAG}/ffmpeg-${BUILD}-linux64-gpl.tar.xz"
-          echo "Downloading ${URL}"
-          curl -fL -o ffmpeg.tar.xz "$URL"
-          echo "${EXPECTED}  ffmpeg.tar.xz" | sha256sum -c -
-          tar -xf ffmpeg.tar.xz
+          mkdir -p ffmpeg-cache
+          if [ -f "ffmpeg-cache/ffmpeg.tar.xz" ]; then
+            echo "Using cached download"
+          else
+            echo "Downloading ${URL}"
+            curl -fL -o ffmpeg-cache/ffmpeg.tar.xz "$URL"
+          fi
+          echo "${EXPECTED}  ffmpeg-cache/ffmpeg.tar.xz" | sha256sum -c -
+          tar -xf ffmpeg-cache/ffmpeg.tar.xz
           mkdir -p ffmpeg
           cp "ffmpeg-${BUILD}-linux64-gpl/bin/ffmpeg" ffmpeg/
           cp "ffmpeg-${BUILD}-linux64-gpl/bin/ffprobe" ffmpeg/
           chmod +x ffmpeg/ffmpeg ffmpeg/ffprobe
-          rm -rf "ffmpeg-${BUILD}-linux64-gpl" ffmpeg.tar.xz
+          rm -rf "ffmpeg-${BUILD}-linux64-gpl"
           ls -la ffmpeg/
 
       - name: Install dependencies
@@ -201,7 +228,7 @@ jobs:
           echo "Sunnify-Linux verified: $((size / 1048576)) MB"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-build
           path: dist/Sunnify-Linux
@@ -214,13 +241,29 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: "pip"
+
+      - name: Cache FFmpeg archive
+        id: ffmpeg-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ffmpeg-cache
+          # Cache is invalidated automatically the moment any env var
+          # in the key changes - so a version bump auto-busts the cache.
+          key: ffmpeg-${{ runner.os }}-${{ env.FFMPEG_BTBN_BUILD }}-${{ env.FFMPEG_MAC_VERSION }}
+
+      - name: Cache FFmpeg archive
+        id: ffmpeg-cache-mac
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ffmpeg-cache
+          key: ffmpeg-${{ runner.os }}-${{ env.FFMPEG_BTBN_BUILD }}-${{ env.FFMPEG_MAC_VERSION }}
 
       - name: Download and verify FFmpeg
         run: |
@@ -228,19 +271,22 @@ jobs:
           VERSION="${{ env.FFMPEG_MAC_VERSION }}"
           EXP_FF="${{ env.FFMPEG_MAC_FFMPEG_SHA256 }}"
           EXP_FP="${{ env.FFMPEG_MAC_FFPROBE_SHA256 }}"
-
-          curl -fL -o ffmpeg.zip "https://evermeet.cx/ffmpeg/ffmpeg-${VERSION}.zip"
-          shasum -a 256 -c <(echo "${EXP_FF}  ffmpeg.zip")
-          curl -fL -o ffprobe.zip "https://evermeet.cx/ffmpeg/ffprobe-${VERSION}.zip"
-          shasum -a 256 -c <(echo "${EXP_FP}  ffprobe.zip")
-
-          unzip -o ffmpeg.zip -d ffmpeg-temp
-          unzip -o ffprobe.zip -d ffmpeg-temp
+          mkdir -p ffmpeg-cache
+          if [ ! -f "ffmpeg-cache/ffmpeg.zip" ]; then
+            curl -fL -o ffmpeg-cache/ffmpeg.zip "https://evermeet.cx/ffmpeg/ffmpeg-${VERSION}.zip"
+          fi
+          if [ ! -f "ffmpeg-cache/ffprobe.zip" ]; then
+            curl -fL -o ffmpeg-cache/ffprobe.zip "https://evermeet.cx/ffmpeg/ffprobe-${VERSION}.zip"
+          fi
+          shasum -a 256 -c <(echo "${EXP_FF}  ffmpeg-cache/ffmpeg.zip")
+          shasum -a 256 -c <(echo "${EXP_FP}  ffmpeg-cache/ffprobe.zip")
+          unzip -o ffmpeg-cache/ffmpeg.zip -d ffmpeg-temp
+          unzip -o ffmpeg-cache/ffprobe.zip -d ffmpeg-temp
           mkdir -p ffmpeg
           mv ffmpeg-temp/ffmpeg ffmpeg/
           mv ffmpeg-temp/ffprobe ffmpeg/
           chmod +x ffmpeg/ffmpeg ffmpeg/ffprobe
-          rm -rf ffmpeg-temp ffmpeg.zip ffprobe.zip
+          rm -rf ffmpeg-temp
           ls -la ffmpeg/
 
       - name: Install dependencies
@@ -272,7 +318,7 @@ jobs:
           echo "Sunnify-macOS.zip verified: $((size / 1048576)) MB"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-build
           path: dist/Sunnify-macOS.zip
@@ -292,12 +338,12 @@ jobs:
         # Needed both for syft (req.txt + source tree) and for the source
         # tarball we attest below. Pinning to the tag is what makes the
         # source tarball deterministic per release.
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: ${{ github.event.inputs.tag }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ./artifacts
 
@@ -443,7 +489,7 @@ jobs:
           done
 
       - name: Upload assets to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.event.inputs.tag }}
           # If dry_run, keep the release as a draft so it isn't user-visible.
@@ -456,6 +502,38 @@ jobs:
             sunnify-sbom.cdx.json
             sunnify-${{ github.event.inputs.tag }}-source.tar.gz
             checksums.txt
+
+      - name: Workflow summary
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          DRY: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "## ${TAG} release - summary"
+            echo ""
+            if [ "$DRY" = "true" ]; then
+              echo "**DRY-RUN**: release marked as draft, Homebrew cask job skipped."
+              echo ""
+            fi
+            echo "### Assets uploaded"
+            echo ""
+            echo '```'
+            cat checksums.txt
+            echo '```'
+            echo ""
+            echo "### Attestations published"
+            echo ""
+            echo "Verify any binary against this release:"
+            echo ""
+            echo '```bash'
+            echo "gh attestation verify Sunnify-Linux \\"
+            echo "  --repo ${{ github.repository }}"
+            echo '```'
+            echo ""
+            echo "Predicate types signed (Sigstore via runner OIDC, Rekor log entry):"
+            echo "- \`https://slsa.dev/provenance/v1\` - build provenance for each binary + the source tarball"
+            echo "- \`https://cyclonedx.org/bom\` - SBOM attestation binding each binary to the SBOM"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   update-homebrew:
     name: Update Homebrew Cask
@@ -481,7 +559,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,6 +398,20 @@ jobs:
           output-file: sunnify-sbom.cdx.json
           upload-release-assets: false
 
+      - name: Scan SBOM for known CVEs (osv-scanner)
+        # Pre-flight check: refuses to ship a release with a HIGH-severity
+        # CVE in any of the dependencies syft just enumerated. Google-
+        # maintained, queries the OSV.dev database. Fails closed so a new
+        # CVE in a transitive dep blocks the upload until the maintainer
+        # either bumps the dep or explicitly waives via a code change here.
+        # ref: https://google.github.io/osv-scanner/
+        uses: google/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --sbom=./sunnify-sbom.cdx.json
+            --skip-git
+            --fail-on-vuln=HIGH
+
       - name: Attest build provenance (SLSA L3 via sigstore)
         # Generates a sigstore-signed in-toto provenance attestation linking
         # each binary to this exact workflow run + source commit. Users verify:
@@ -416,7 +430,7 @@ jobs:
         # "provenance" predicate above), so consumers can ask the supply-chain
         # question "what's IN this binary?" against the same chain of trust as
         # "where did this binary come from?".
-        uses: actions/attest-sbom@10926c72720ffc3f7b666661c8e55b1344e2a365 # v2 (Sep 2024)
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: |
             ./artifacts/windows-build/Sunnify-Windows.exe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,17 +10,30 @@ concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   python-tests:
-    name: Python Tests
+    name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # pyproject.toml declares `requires-python = ">=3.9"`, so we test
+        # the full supported range. `from __future__ import annotations` is
+        # the load-bearing import that keeps PEP 604 unions (`X | None`)
+        # working on 3.9; this matrix would catch a regression if anyone
+        # removes it.
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ permissions:
 
 jobs:
   python-tests:
-    name: Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -26,12 +26,18 @@ jobs:
         # the load-bearing import that keeps PEP 604 unions (`X | None`)
         # working on 3.9; this matrix would catch a regression if anyone
         # removes it.
+        #
+        # We also fan across the three OSes we ship binaries for, so a
+        # platform-specific import or filesystem regression (e.g. case-
+        # sensitive paths only failing on Linux) lands on a red test
+        # before it lands on a user.
+        os: [ubuntu-latest, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 <br/>
 
+<a href="https://github.com/sunnypatell/sunnify-spotify-downloader/actions/workflows/tests.yml"><img alt="Tests" src="https://github.com/sunnypatell/sunnify-spotify-downloader/actions/workflows/tests.yml/badge.svg?branch=main"></a>
+<a href="https://github.com/sunnypatell/sunnify-spotify-downloader/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/sunnypatell/sunnify-spotify-downloader/actions/workflows/codeql.yml/badge.svg?branch=main"></a>
+<a href="SECURITY.md#release-integrity"><img alt="SLSA L3" src="https://img.shields.io/badge/SLSA-L3-3D7BFF?logo=securityscorecard&logoColor=white"></a>
+
+<br/>
+
 <img src="./app.png" alt="Sunnify" height="96" />
 
 <p><em>🎧 Download entire Spotify playlists to local MP3s with embedded artwork and tags. Desktop app, Python core, and a full web stack in one repo.</em></p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,76 @@ Coordinated disclosure is appreciated. If a fix is accepted, we will work with y
 
 ---
 
+## Release integrity
+
+Starting with 2.0.8, every release attaches signed build provenance + SBOM
+attestations so users can verify what they downloaded came from this repository,
+from a specific source commit, built by the workflow they can inspect.
+
+### What's attached to every release
+
+| Asset | What it is |
+| :--- | :--- |
+| `Sunnify-Windows.exe` / `Sunnify-Linux` / `Sunnify-macOS.zip` | Platform binaries |
+| `sunnify-sbom.cdx.json` | CycloneDX SBOM describing the delivered artifacts |
+| `sunnify-vX.Y.Z-source.tar.gz` | `git archive` of the source at the release commit |
+| `checksums.txt` | SHA256 of every asset, in `sha256sum -c` format |
+
+### Three independent verification paths
+
+**1. Plain checksums** — no extra tooling. Download `checksums.txt` and the
+   asset you care about, then:
+
+   ```bash
+   sha256sum -c checksums.txt --ignore-missing
+   ```
+
+**2. SLSA L3 build provenance** — proves the binary came from a specific
+   commit in this repo, built by this workflow, in an isolated runner.
+   Signed with the runner's short-lived Sigstore identity and logged to the
+   Rekor public transparency log. Requires the GitHub CLI:
+
+   ```bash
+   gh attestation verify Sunnify-Linux \
+     --repo sunnypatell/sunnify-spotify-downloader
+   ```
+
+**3. SBOM attestation** — proves the SBOM published alongside the release
+   was produced from those exact binaries (binary digest -> SBOM digest
+   binding), signed by the same Sigstore chain. Same command, same repo;
+   `gh attestation verify` accepts the binary and finds both predicate
+   types automatically.
+
+### Supply-chain practices in the build
+
+- **FFmpeg pinned + SHA256-verified.** The build refuses to extract an
+  archive whose SHA256 doesn't match a value embedded in the workflow file,
+  so a CDN swap or compromised mirror aborts the build instead of silently
+  shipping the wrong binary.
+- **All third-party GitHub Actions SHA-pinned** with a trailing `# vX.Y.Z`
+  comment. A tag re-target cannot silently swap an action's code.
+- **Per-job least-privilege permissions.** Build jobs are `contents: read`
+  only; only the upload job has `attestations: write` + `id-token: write`.
+- **Dependency review on pull requests.** A PR that introduces a new
+  dependency with a known high-severity CVE is blocked at the PR status
+  check before it can merge.
+- **CodeQL** runs weekly + on every PR.
+
+### What we explicitly do not have
+
+- **Code-signing certificates** (macOS notarization / Windows Authenticode).
+  Both require paid issuer accounts; the project is unfunded. macOS users
+  bypass Gatekeeper with the `sudo xattr -cr /Applications/Sunnify.app`
+  command documented in the install instructions; Windows users see
+  SmartScreen "unknown publisher" on first launch.
+- **Reproducible builds.** PyInstaller is non-deterministic by default and
+  making it deterministic for this app is a research project, not a
+  weekend task. The provenance attestation still binds each binary to the
+  source commit, but two builds of the same commit will not produce
+  byte-identical artifacts.
+
+---
+
 ## Legal Note
 
 This project is provided "as is" without warranty of any kind. It is an educational demonstration and is not intended for unauthorized downloading of copyrighted content. The developer assumes no liability for how this software is used. See [DISCLAIMER.md](DISCLAIMER.md) for complete legal terms.

--- a/tests/test_spotify_downloader.py
+++ b/tests/test_spotify_downloader.py
@@ -8,6 +8,7 @@ import sys
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 
@@ -51,6 +52,11 @@ class TestGetFfmpegPath:
             result = get_ffmpeg_path()
             assert result == str(ffmpeg_dir)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX path probe; os.path.join uses backslash on Windows so the "
+        "exists() mock keyed on '/opt/homebrew/bin/ffmpeg' never matches",
+    )
     def test_homebrew_ffmpeg(self, tmp_path):
         """Test homebrew FFmpeg detection."""
         from Spotify_Downloader import get_ffmpeg_path
@@ -70,6 +76,11 @@ class TestGetFfmpegPath:
             result = get_ffmpeg_path()
             assert result == "/opt/homebrew/bin"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX path probe; os.path.join uses backslash on Windows so the "
+        "exists() mock keyed on '/usr/bin/ffmpeg' never matches",
+    )
     def test_system_ffmpeg_linux(self, tmp_path):
         """Test system FFmpeg detection on Linux."""
         from Spotify_Downloader import get_ffmpeg_path


### PR DESCRIPTION
Hardens the release pipeline end-to-end and adds the credibility-grade supply-chain pieces that don't require paid certs or manual triage.

## What's in here

### Release pipeline (`release.yml`)
- **FFmpeg pinned + SHA256-verified** on all three platforms (BtbN autobuild + evermeet.cx versioned). Build aborts before extraction if any download doesn't match the pinned hash. Documented bump procedure at top of file.
- **Per-platform sanity check** on the built binary (file format, size floor, bundled FFmpeg presence) so a corrupt build self-aborts before reaching upload.
- **Pre-upload sanity check** in the upload job verifies all three artifacts arrived intact and have the expected format/structure.
- **Idempotent re-runs**: deletes existing release assets before upload, so a partial-failure re-run can't stack stale bytes alongside fresh ones.
- **Concurrency group per-tag** (not per-branch), so two releases on different tags don't race.
- **Cask update via Python with line-anchored regex** + strict tag/SHA256 input validation. Fails closed if exactly-once substitution didn't fire.
- **`dry_run` workflow input**: keeps the release as draft and skips the cask update job. Used to validate this pipeline end-to-end (6 dry-runs passed).
- **Cache + reuse of FFmpeg archive** keyed on the pinned version, with SHA verification on every hit.
- **`$GITHUB_STEP_SUMMARY` at end of run** with checksums + the `gh attestation verify` command users would run.

### Supply-chain attestations (sigstore-signed, Rekor transparency log)
- **SLSA L3 build provenance** for each binary + the source tarball (`actions/attest-build-provenance@v4.1.0`)
- **CycloneDX SBOM attestation** binding binary digest to SBOM digest (`actions/attest@v4.1.0` with `predicate-type=cyclonedx/bom/v1.5`; canonical replacement for the deprecated `attest-sbom` wrapper)
- **OSV CVE pre-flight scan** of the SBOM (`google/osv-scanner-action@v2.3.8`). Refuses to ship a release if any dependency has a known HIGH-severity CVE.

### New release assets
- `Sunnify-Windows.exe`, `Sunnify-Linux`, `Sunnify-macOS.zip` (existing)
- `sunnify-sbom.cdx.json` — CycloneDX SBOM
- `sunnify-vX.Y.Z-source.tar.gz` — `git archive` of the release commit (deterministic; signed by the same provenance chain)
- `checksums.txt` — SHA256 of every asset, in `sha256sum -c` format

### Test + lint workflows
- **`tests.yml`**: matrix expanded to [Ubuntu, macOS-14, Windows] × [Python 3.9-3.13], `fail-fast: false`. Catches platform-specific imports and verifies `from __future__ import annotations` keeps 3.9-compat working.
- **`lint.yml`**: timeout + explicit `permissions: contents: read`.

### New workflow: `dependency-review.yml`
- PR-only check that fails a PR introducing a dep with a known HIGH-severity CVE. Distinct from Dependabot (which is intentionally disabled at the repo level). No emails, no auto-PRs, no scheduled runs.

### Documentation
- **`SECURITY.md`**: new "Release integrity" section covering the three independent verification paths (checksums, `gh attestation verify` for provenance, same command for SBOM attestation) with concrete commands. Documents the supply-chain practices in the build and is honest about what's deliberately not in scope (paid signing, reproducible builds).
- **`README.md`**: Tests / CodeQL / SLSA L3 badges next to the existing ones.

### Action hygiene
- **All third-party actions SHA-pinned** with trailing `# vX.Y.Z` comments. Tag re-targets can't silently swap action code.
- **Per-job least-privilege `permissions:` blocks**.
- **All actions on Node.js 24** (GitHub deprecates Node.js 20 on Jun 16, 2026).
- **`timeout-minutes`** on every job to prevent runaway builds eating the 6h default.

## Validation
- Six dry-runs on `v2.0.8-cidry` throwaway tag, all green (deleted after).
- Multi-agent adversarial review: 20 raw findings reviewed by independent verifiers, 11 confirmed real and fixed, 9 rejected as not-real-at-this-scale, 0 blockers remaining.

## What's NOT in here (deliberately)
- Code-signing certs (macOS notarization / Windows Authenticode) — paid issuer accounts.
- Reproducible PyInstaller builds — research project; the provenance attestation still binds each binary to its source commit.
- Dependabot — disabled at the repo level (the email storm was a problem; `dependency-review-action` covers the PR-time case without emails).
- OpenSSF Scorecard badge — would surface findings that need triage.

## After merge
- Re-run the workflow against `v2.0.8` (`dry_run=false`) to attach the new attestations + SBOM + source tarball + checksums to the existing release; the binaries are rebuilt with the pinned FFmpeg.