### PR TITLE
feat(providers): add album name to direct track downloads

### DIFF
--- a/spotifydown_api.py
+++ b/spotifydown_api.py
@@ -128,6 +128,7 @@ class SpotifyEmbedAPI:
     _EMBED_PLAYLIST_URL = "https://open.spotify.com/embed/playlist/{playlist_id}"
     _EMBED_ALBUM_URL = "https://open.spotify.com/embed/album/{playlist_id}"
     _EMBED_TRACK_URL = "https://open.spotify.com/embed/track/{track_id}"
+    _TRACK_PAGE_URL = "https://open.spotify.com/track/{track_id}"
     _OEMBED_URL = "https://open.spotify.com/oembed"
     _SPCLIENT_URL = "https://spclient.wg.spotify.com/playlist/v2/playlist/{playlist_id}"
     _NEXT_DATA_PATTERN = re.compile(r'<script id="__NEXT_DATA__"[^>]*>([^<]+)</script>')
@@ -518,6 +519,38 @@ class SpotifyEmbedAPI:
             raw=dict(track),
         )
 
+    @staticmethod
+    def _parse_og_description_album(html: str) -> str | None:
+        """Extract album name from og:description on a Spotify track page"""
+        m = re.search(
+            r'<meta\s+[^>]*property="og:description"[^>]*content="([^"]*)"',
+            html,
+        )
+        if not m:
+            return None
+        parts = m.group(1).split(" · ")
+        # probably [artist, album, "Song", year] fingers crossed
+        if len(parts) >= 2:
+            return parts[1].strip()
+        return None
+
+    _OG_HEADERS = {
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "accept-language": "en-US,en;q=0.9",
+        "user-agent": "Mozilla/5.0",
+    }
+
+    def _fetch_track_album_from_page(self, track_id: str) -> str | None:
+        """Fetch album name from the regular Spotify track page via OG tags!!!"""
+        url = self._TRACK_PAGE_URL.format(track_id=track_id)
+        try:
+            resp = self._session.get(url, headers=self._OG_HEADERS, timeout=15)
+            if resp.status_code == 200:
+                return self._parse_og_description_album(resp.text)
+        except requests.RequestException:
+            pass
+        return None
+
     def _fetch_track_metadata(self, track_id: str) -> TrackInfo | None:
         """Fetch metadata for a single track from its embed page."""
         url = self._EMBED_TRACK_URL.format(track_id=track_id)
@@ -562,10 +595,11 @@ class SpotifyEmbedAPI:
         elif isinstance(rd, str):
             release_date = rd
 
-        # Try to get album name
         album = None
-        # Album info might be in relatedEntityUri or other fields
-        # For now, we'll leave it None as individual track embeds don't include album
+        if isinstance(entity.get("album"), dict):
+            album = entity["album"].get("name")
+        if not album:
+            album = self._fetch_track_album_from_page(track_id)
 
         return TrackInfo(
             id=track_id,
@@ -876,3 +910,4 @@ __all__ = [
     "extract_track_id",
     "sanitize_filename",
 ]
+ 

--- a/spotifydown_api.py
+++ b/spotifydown_api.py
@@ -137,6 +137,13 @@ class SpotifyEmbedAPI:
         self._session = session or requests.Session()
         self._cached_token: str | None = None
         self._token_expiry: float = 0
+        # Per-instance album cache (track_id -> album name or None). FIFO-
+        # bounded at 256 entries. Used by `_fetch_track_album_from_page` so
+        # re-downloading the same track in one session does not re-hit
+        # Spotify's HTML page. Plain dict instead of @functools.lru_cache
+        # because the lru_cache decorator on a method keeps self alive for
+        # the lifetime of the process (B019).
+        self._album_cache: dict[str, str | None] = {}
 
     @staticmethod
     def _deep_find(data: dict, key: str, max_depth: int = 6) -> dict | None:
@@ -519,37 +526,83 @@ class SpotifyEmbedAPI:
             raw=dict(track),
         )
 
+    # og:description on Spotify's social-share page is the canonical source
+    # of album name for a single track. The /embed/track/{id} JSON does not
+    # carry an album field (verified empirically across diverse tracks) and
+    # the oEmbed endpoint only returns title + thumbnail. Format is
+    # `Artist · Album · Song · Year` separated by U+00B7. Used for SEO and
+    # rich-link previews on Twitter/Discord/iMessage, so it has strong
+    # incentive against breakage and has been stable for years.
+    #
+    # Regex uses a lookahead so it matches both attribute orders
+    # (`property=... content=...` and `content=... property=...`); HTML
+    # attribute order is not guaranteed by the spec and Spotify could
+    # silently reorder.
+    _OG_DESCRIPTION_RE = re.compile(
+        r'<meta\s+(?=[^>]*\bproperty="og:description")[^>]*\bcontent="([^"]*)"',
+        re.IGNORECASE,
+    )
+
     @staticmethod
     def _parse_og_description_album(html: str) -> str | None:
-        """Extract album name from og:description on a Spotify track page"""
-        m = re.search(
-            r'<meta\s+[^>]*property="og:description"[^>]*content="([^"]*)"',
-            html,
-        )
-        if not m:
-            return None
-        parts = m.group(1).split(" · ")
-        # probably [artist, album, "Song", year] fingers crossed
-        if len(parts) >= 2:
-            return parts[1].strip()
-        return None
+        """Extract the album name from a Spotify track page's og:description.
 
-    _OG_HEADERS = {
-        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "accept-language": "en-US,en;q=0.9",
-        "user-agent": "Mozilla/5.0",
-    }
+        Returns None for missing tag, malformed format, or empty-after-strip.
+        Decodes HTML entities so titles like "Tom &amp; Jerry" come through
+        as "Tom & Jerry" before they hit the ID3 writer.
+        """
+        import html as _html_module
+
+        match = SpotifyEmbedAPI._OG_DESCRIPTION_RE.search(html)
+        if not match:
+            return None
+        parts = _html_module.unescape(match.group(1)).split(" · ")
+        if len(parts) < 2:
+            return None
+        album = parts[1].strip()
+        return album or None
 
     def _fetch_track_album_from_page(self, track_id: str) -> str | None:
-        """Fetch album name from the regular Spotify track page via OG tags!!!"""
-        url = self._TRACK_PAGE_URL.format(track_id=track_id)
+        """Fetch album name from the regular Spotify track page via og:description.
+
+        Cached per instance so a re-download of the same track in one
+        session doesn't re-pay the HTTP cost. Wraps the HTTP call in the
+        same retry/backoff `_fetch_embed_data` uses so transient network
+        errors don't silently drop the album tag for that track.
+        """
+        if track_id in self._album_cache:
+            return self._album_cache[track_id]
+
+        @retry_on_network_error(
+            max_attempts=3,
+            backoff_factor=1.0,
+            exceptions=(NetworkError, requests.Timeout, requests.ConnectionError),
+        )
+        def _go() -> str | None:
+            url = self._TRACK_PAGE_URL.format(track_id=track_id)
+            try:
+                resp = self._session.get(url, headers=self._headers(), timeout=15)
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                raise NetworkError(f"Network error fetching track page: {exc}") from exc
+            except requests.RequestException:
+                return None
+            if resp.status_code != 200:
+                return None
+            return self._parse_og_description_album(resp.text)
+
         try:
-            resp = self._session.get(url, headers=self._OG_HEADERS, timeout=15)
-            if resp.status_code == 200:
-                return self._parse_og_description_album(resp.text)
-        except requests.RequestException:
-            pass
-        return None
+            album = _go()
+        except NetworkError:
+            # Out of retry budget; treat as no album for this track but
+            # don't cache the failure (next session can try again).
+            return None
+        # Simple bound; evict oldest if we hit capacity. lru would be nicer
+        # but dict insertion order + popitem(last=False) gives FIFO which
+        # is plenty for a per-session deduplication cache.
+        if len(self._album_cache) >= 256:
+            self._album_cache.pop(next(iter(self._album_cache)))
+        self._album_cache[track_id] = album
+        return album
 
     def _fetch_track_metadata(self, track_id: str) -> TrackInfo | None:
         """Fetch metadata for a single track from its embed page."""
@@ -595,11 +648,11 @@ class SpotifyEmbedAPI:
         elif isinstance(rd, str):
             release_date = rd
 
-        album = None
-        if isinstance(entity.get("album"), dict):
-            album = entity["album"].get("name")
-        if not album:
-            album = self._fetch_track_album_from_page(track_id)
+        # The embed JSON for a single track has never included album
+        # (verified empirically across all currently-tested tracks); fall
+        # straight to the og:description scrape with no need for the
+        # `if entity.get("album")` branch that was sitting here dead.
+        album = self._fetch_track_album_from_page(track_id)
 
         return TrackInfo(
             id=track_id,
@@ -910,4 +963,3 @@ __all__ = [
     "extract_track_id",
     "sanitize_filename",
 ]
- 

--- a/tests/test_spotifydown_api.py
+++ b/tests/test_spotifydown_api.py
@@ -463,6 +463,150 @@ class TestSpotifyEmbedAPI:
         assert fetched_urls == ["https://open.spotify.com/embed/album/ALBUMID"]
 
 
+class TestParseOgDescriptionAlbum:
+    """Parser-level tests for the og:description -> album extraction.
+
+    The format `Artist · Album · Song · Year` is Spotify's social-share
+    canonical and has been stable for years. These tests pin the parser
+    to that contract and to the regex's attribute-order tolerance + HTML
+    entity decoding.
+    """
+
+    def test_extracts_album_from_canonical_format(self):
+        html = '<meta property="og:description" content="The Weeknd · After Hours · Song · 2020">'
+        assert SpotifyEmbedAPI._parse_og_description_album(html) == "After Hours"
+
+    def test_handles_attribute_order_reversed(self):
+        """Attribute order in HTML isn't guaranteed by spec; the regex
+        uses a lookahead so it matches either order. A Spotify deploy
+        that reorders meta attributes must not silently kill albums."""
+        html = (
+            '<meta content="Queen · A Night At The Opera · Song · 1975" property="og:description">'
+        )
+        assert SpotifyEmbedAPI._parse_og_description_album(html) == "A Night At The Opera"
+
+    def test_decodes_html_entities(self):
+        """Albums with `&` or `\"` get HTML-encoded in the meta content;
+        the parser must unescape before returning, otherwise the album
+        tag ends up `Tom &amp; Jerry` in the ID3 frame."""
+        html = (
+            '<meta property="og:description" '
+            'content="Tom &amp; Jerry · Greatest &quot;Hits&quot; · Song · 2010">'
+        )
+        assert SpotifyEmbedAPI._parse_og_description_album(html) == 'Greatest "Hits"'
+
+    def test_returns_none_when_tag_missing(self):
+        assert SpotifyEmbedAPI._parse_og_description_album("<html></html>") is None
+
+    def test_returns_none_when_format_too_short(self):
+        """One-part og:description (no album segment) returns None
+        rather than misreporting the artist as the album."""
+        html = '<meta property="og:description" content="Just one part">'
+        assert SpotifyEmbedAPI._parse_og_description_album(html) is None
+
+    def test_returns_none_when_album_empty_after_strip(self):
+        html = '<meta property="og:description" content="Artist ·     · Song · 2020">'
+        assert SpotifyEmbedAPI._parse_og_description_album(html) is None
+
+
+class TestFetchTrackAlbumFromPage:
+    """Tests for the per-track HTML scrape + caching + retry shell."""
+
+    def _stub_session_returning(self, body: str, status: int = 200):
+        """Build a fake session that returns one canned response."""
+        from unittest.mock import MagicMock
+
+        resp = MagicMock(status_code=status, text=body)
+        sess = MagicMock()
+        sess.get = MagicMock(return_value=resp)
+        return sess
+
+    def test_fetcher_returns_album_from_real_shape(self):
+        body = (
+            '<meta property="og:description" content="Linkin Park · Hybrid Theory · Song · 2000">'
+        )
+        api = SpotifyEmbedAPI(session=self._stub_session_returning(body))
+        assert api._fetch_track_album_from_page("abc123") == "Hybrid Theory"
+
+    def test_fetcher_returns_none_on_non_200(self):
+        """Spotify dropping a 404/500 must not corrupt downstream metadata."""
+        api = SpotifyEmbedAPI(session=self._stub_session_returning("error page", status=500))
+        assert api._fetch_track_album_from_page("abc123") is None
+
+    def test_fetcher_caches_result_to_avoid_re_fetch(self):
+        """Second call for the same track_id must NOT hit the session;
+        re-downloading the same playlist would otherwise re-pay the
+        HTTP cost per track."""
+        body = '<meta property="og:description" content="Daft Punk · Discovery · Song · 2001">'
+        sess = self._stub_session_returning(body)
+        api = SpotifyEmbedAPI(session=sess)
+        assert api._fetch_track_album_from_page("xyz") == "Discovery"
+        assert api._fetch_track_album_from_page("xyz") == "Discovery"
+        assert sess.get.call_count == 1
+
+    def test_fetcher_caches_none_too(self):
+        """A track without an og:description tag should also be cached as
+        None so a retry-loop in the caller doesn't repeatedly re-fetch."""
+        api = SpotifyEmbedAPI(session=self._stub_session_returning("<html></html>", status=200))
+        sess = api._session
+        assert api._fetch_track_album_from_page("no-og") is None
+        assert api._fetch_track_album_from_page("no-og") is None
+        assert sess.get.call_count == 1
+
+    def test_fetcher_uses_default_user_agent(self):
+        """Use the existing Chrome UA constant rather than `Mozilla/5.0`
+        alone, which is short enough to trip Spotify's bot heuristics."""
+        from spotifydown_api import _DEFAULT_USER_AGENT
+
+        body = '<meta property="og:description" content="Artist · Album · Song · 2020">'
+        sess = self._stub_session_returning(body)
+        api = SpotifyEmbedAPI(session=sess)
+        api._fetch_track_album_from_page("ua-test")
+        _, kwargs = sess.get.call_args
+        assert kwargs["headers"]["user-agent"] == _DEFAULT_USER_AGENT
+
+    def test_fetcher_retries_then_returns_none_on_persistent_network_error(self):
+        """Transient network errors back off (3 attempts) and degrade
+        gracefully to no album rather than blowing up the whole
+        per-track metadata fetch path."""
+        from unittest.mock import MagicMock
+
+        import requests as _requests
+
+        sess = MagicMock()
+        sess.get = MagicMock(side_effect=_requests.ConnectionError("boom"))
+        api = SpotifyEmbedAPI(session=sess)
+        assert api._fetch_track_album_from_page("flaky") is None
+        # 3 retry attempts before giving up
+        assert sess.get.call_count == 3
+
+    def test_cache_eviction_when_at_capacity(self):
+        """Cache is bounded at 256 entries; oldest gets evicted FIFO."""
+        from unittest.mock import MagicMock
+
+        # Build a session that returns the album corresponding to track_id
+        sess = MagicMock()
+
+        def _resp(url, **_kw):
+            tid = url.rsplit("/", 1)[-1]
+            r = MagicMock(status_code=200)
+            r.text = f'<meta property="og:description" content="A · album-{tid} · Song · 2020">'
+            return r
+
+        sess.get = MagicMock(side_effect=_resp)
+        api = SpotifyEmbedAPI(session=sess)
+        # Fill cache to capacity + 1
+        for i in range(257):
+            api._fetch_track_album_from_page(f"t{i}")
+        # t0 should be evicted, t1..t256 should still be cached
+        assert "t0" not in api._album_cache
+        assert "t256" in api._album_cache
+        # Re-fetching t0 hits the network again
+        before = sess.get.call_count
+        api._fetch_track_album_from_page("t0")
+        assert sess.get.call_count == before + 1
+
+
 class TestPlaylistClient:
     """Tests for PlaylistClient class."""
 


### PR DESCRIPTION

<div align="center">

# Pull Request

</div>

## Summary

Direct Spotify track downloads now include the album name in the file metadata, matching album downloads. Since the Spotify embed API does not provide album information for single tracks, the album name is now extracted from the regular track page's `og:description` meta tag.

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] perf (performance)
- [ ] chore (build, tooling, refactors)

## Scope (select all that apply)

- [ ] Desktop (PyQt5 GUI)
- [ ] Backend (Flask API)
- [ ] Webclient (Next.js)
- [x] Core Providers (`spotifydown_api.py`)
- [ ] Scripts/Diagnostics (`scripts/check_api_status.py`)
- [ ] Documentation

## Linked issues

None

## Details

What changed: `_fetch_track_metadata()` in `spotifydown_api.py` previously set `album = None` for single-track downloads because album information was not available from the track embed page. Added a fallback that loads the regular Spotify track page (using a simple user-agent to get the server-rendered version) and reads the `og:description` meta tag. The tag format is `Artist · Album · Song · Year`, and the album name is extracted from it.

Ux Notes: Direct track downloads now include album metadata

Endpoint changes: No new endpoints. Adds one lightweight HTP request per single-track download to `open.spotify.com/track/{id}`.

## How I tested this

- **OS and versions:** macOS Tahoe 26.1 (arm64)
- **Python:** Python 3.12.4
- **Commands run:**

```bash
pytest tests/test_spotifydown_api.py -v 
  ```
- [ ] None

- If any, describe the break and migration steps

  

## Risks and rollbacks

  

- Only tested on macOS The OG tag scraping relies on Spotify serving the server-rendered page, which fails if layout is changed.

- Falls back silently to no album on any failure.

  

## Checklist

  

### Code quality

- [ ] Python: `ruff check .` and `ruff format --check .` pass

- [ ] Webclient: `npm run lint`, `npm run typecheck`, `npm run format:check` pass

- [x] No new warnings introduced (or warnings are intentional and documented)

  

### Testing

- [x] I ran `pytest tests/ -v` and all tests pass

- [x] I ran `python scripts/check_api_status.py` or validated relevant endpoints

- [ ] FFmpeg is on PATH (`ffmpeg -version`) and `yt-dlp` is up to date when desktop is affected

- [x] Tests or manual validation steps included

  

### Documentation

- [ ] Docs updated where behavior changed (README/CONTRIBUTING/etc.)

- [ ] Backend changes documented in README or API docs

  

### Security and Legal

- [x] I read the SECURITY.md and Legal sections to avoid adding risky functionality

- [x] I understand this is an **educational project** and my contribution preserves that nature

- [x] Webclient changes use `NEXT_PUBLIC_API_BASE` instead of hardcoded URLs

- [x] No secrets, credentials, or sensitive data in the code